### PR TITLE
Add yahoo_devoloper_network_api_key to settings.yml.sample

### DIFF
--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -1,2 +1,3 @@
 google_maps_api_key: XXXX
 google_places_apikey: XXXX
+yahoo_developer_network_api_key: XXXX


### PR DESCRIPTION
settings.yml.sampleにyahoo_developer_network_api_keyのサンプルを追加しました．