### PR TITLE
Add reading environment variable to SlackBot.rb

### DIFF
--- a/FBot.rb
+++ b/FBot.rb
@@ -22,7 +22,7 @@ module FBot
     address = URI.encode(address)
     hash = Hash.new
  
-    reqUrl = "#{BASE_URL_GEOCODE}?address=#{address}&sensor=false&language=ja&key=" + @config["google_maps_api_key"]
+    reqUrl = "#{BASE_URL_GEOCODE}?address=#{address}&sensor=false&language=ja&key=" + @google_maps_api
 
     response = Net::HTTP.get_response(URI.parse(reqUrl))
 
@@ -64,7 +64,7 @@ module FBot
     hash = Hash.new
     hash['distance'] = 0
     hash['duration'] = 0
-    reqUrl = "#{BASE_URL_DIRECTIONS}?origin=#{start['lat']},#{start['lng']}&destination=#{goal['lat']},#{goal['lng']}&language=ja&mode=#{mode}&key=" + @config["google_maps_api_key"]
+    reqUrl = "#{BASE_URL_DIRECTIONS}?origin=#{start['lat']},#{start['lng']}&destination=#{goal['lat']},#{goal['lng']}&language=ja&mode=#{mode}&key=" + @google_maps_api
 
     response = Net::HTTP.get_response(URI.parse(reqUrl))
 

--- a/SlackBot.rb
+++ b/SlackBot.rb
@@ -7,6 +7,11 @@ require 'net/https'
 class SlackBot
   def initialize(settings_file_path = "settings.yml")
     @config = YAML.load_file(settings_file_path) if File.exist?(settings_file_path)
+
+    # This code assumes to set incoming webhook url as evironment variable in Heroku
+    # SlackBot uses settings.yml as config when it serves on local
+
+    @google_maps_api = ENV['GOOGLE_MAPS_API_KEY'] || @config["google_maps_api_key"]
   end
 
   def naive_respond(params, options = {})


### PR DESCRIPTION
Heroku では API キーを環境変数で設定するため，環境変数を読み込めるように以下の点を編集しました．
+ SlackBot.rb に環境変数を読み込むための機能を追加し，インスタンス変数を作成
+ 上記で作成したインスタンス変数を FBot.rb で使用するように変更