### PR TITLE
Arrange output of SYBot

### DIFF
--- a/SYBot.rb
+++ b/SYBot.rb
@@ -10,7 +10,8 @@ require 'uri'
 require 'yaml'
 require 'net/https'
 
- GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
+ #GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
+ GITHUB_API = "https://api.github.com/repos/yoshida-shu/SYBot/issues"
 
   module SYBot
 
@@ -37,38 +38,39 @@ require 'net/https'
         text_hedder = "\<" << issues_url << "\|\*issues\*\>\n"
         titles = text_hedder << "\n"
 
-        issue_list.each do |issue|     
+        issue_list.each do |issue|
           titles << ("\*Title: \*\<" << issue["html_url"])
           titles << ("\|" << issue["title"] << ">")
           titles << "\n"
-        end 
+        end
         ret =  {text: titles}.merge(options).to_json
       end
 
     when "c" then
-      new_issue = {:title => "default",:body => "default",:assignee => @git_username}
+      new_issue = {:title => "default",:body => "Not edited yet\(created by Swimmy\)",:assignee => @git_username}
       if (i1 = text.index("t:",crud[1] + "make issue".size)) != nil then
         if (i2 = text.index("b:",i1+2)) != nil then
           new_issue["title"] = text[i1+2...i2-1]
           new_issue["body"] = text[i2+2...-1]
           make_issue(new_issue)
-          ret = {text: "created"}.merge(options).to_json
+          ret = {:text => "created"}.merge(options).to_json
         else
-          new_issue[title] = text[clud[1]...-1]
+          new_issue["title"] = text[i1+2...-1]
           err = make_issue(new_issue)
           if err == nil
-            ret = {text: "created"}.merge(options).to_json
+            ret = {:text => "created"}.merge(options).to_json
           else
-            ret = {text: "creation faild:" + err}.merge(options).to_json
+            p "hay!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+            ret = {:text => ("creation faild:" + err)}.merge(options).to_json
           end
         end
 
       else
-        ret = {text: "make issue t:(title)[b:body]"}.merge(options).to_json
+        ret = {:text => "make issue t:(title)[b:body]"}.merge(options).to_json
       end
 
     else
-      ret = {text: "usage:\n \nget issue\nmake issue :t(title)[b:(body)]"}.merge(options).to_json
+      ret = {:text => "usage:\n \nget issue\nmake issue :t(title)[b:(body)]"}.merge(options).to_json
     end
     return ret
   end
@@ -105,4 +107,75 @@ require 'net/https'
     end
     return JSON.parse(response.body)["message"]
   end
+
+  def make_link(url,label)
+    titles = "\<"
+    titles << url << "\|" << label << "\>"
+    return titles
+  end
+  
+  def git_webhook_respond(params,options = {})
+      if params["action"] == nil then
+        ret = {:text => "Faild to get action"}.merge(options).to_json
+      else
+#params は IndifferentHash で，最も上の階層のvalueの型がStringであるため，eval で Hash に直しています．
+        issue_h =  eval(params[:issue])
+        repo_h = eval(params[:repository])
+        act = params["action"]
+        repository_name = repo_h["name"] || "None"
+        repository_url = repo_h["html_url"] || "None"
+        issue_title = issue_h["title"] || "None"
+        issue_url = issue_h["html_url"] || "None"
+        issues_url = repository_url << "\/issues" || "None"
+        user_name = issue_h["user"]["login"] || "None"
+        assignee = issue_h["user"]["assignee"] || "None"
+
+        text_hedder = "\<" << issues_url << "\|\*issues\*\>\n"
+        ret_txt = text_hedder << "\n"
+
+        case act
+        when "opened" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって， \*issue\*\: " 
+            ret_txt << make_link(issue_url,issue_title) << "が作成されました．"
+        when "reopened" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって， \*issue\*\:" 
+            ret_txt << make_link(issue_url,issue_title) << "が再び開かれました．"
+        when "closed" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって， \*issue\*\:" 
+            ret_txt << make_link(issue_url,issue_title) << "が閉鎖されました．"
+        when "assigned" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって，" 
+            ret_txt << user_name << "に \*issue\*\:"
+            ret_txt << make_link(issue_url,issue_title) << "が割り当てられました．"
+        when "unassigned" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって，" 
+            ret_txt << user_name << "が \*issue\*\:"
+            ret_txt << make_link(issue_url,issue_title) << "の担当から外されました．"
+        when "edited" then
+            ret_txt = make_link(repository_url,repository_name) << "\:" 
+            ret_txt << user_name << "によって， \*issue\*\:" 
+            ret_txt << make_link(issue_url,issue_title) << "が編集されました．"
+        else
+            ret_txt = nil
+        end
+      end
+        ret = {:text => ret_txt}.merge(options).to_json
+        https_post(@slack_incoming_webhook,ret)
+        return ret
+   end
+
+   def https_post(url,json_data)
+        uri = URI.parse(url)
+        request = Net::HTTP::Post.new(uri)
+        request.body = json_data
+        req_options = {use_ssl: uri.scheme == "https"}
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+        end
+   end
 end

--- a/SYBot.rb
+++ b/SYBot.rb
@@ -10,8 +10,8 @@ require 'uri'
 require 'yaml'
 require 'net/https'
 
- #GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
- GITHUB_API = "https://api.github.com/repos/yoshida-shu/SYBot/issues"
+ GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
+ #GITHUB_API = "https://api.github.com/repos/yoshida-shu/SYBot/issues"##for test
 
   module SYBot
 

--- a/SYBot.rb
+++ b/SYBot.rb
@@ -34,13 +34,12 @@ require 'net/https'
         end
         repository_url = issue_list[0]["repository_url"].gsub(/api.github.com\/repos/,"github.com")
         issues_url = repository_url << "\/issues"
-        text_hedder = "issues\nLink" << issues_url
+        text_hedder = "\<" << issues_url << "\|\*issues\*\>\n"
         titles = text_hedder << "\n"
 
-        issue_list.each do |issue|
-          titles << ("Title: " << issue["title"] )
-          titles << "\n"
-          titles << ("Link: " << issue["html_url"])
+        issue_list.each do |issue|     
+          titles << ("\*Title: \*\<" << issue["html_url"])
+          titles << ("\|" << issue["title"] << ">")
           titles << "\n"
         end 
         ret =  {text: titles}.merge(options).to_json

--- a/SlackBot.rb
+++ b/SlackBot.rb
@@ -15,7 +15,8 @@ class SlackBot
     @git_password = ENV['GIT_PASSWORD'] || @config["git_password"]
     @google_places_api_key = ENV['GOOGLE_PLACES_API_KEY'] || @config["google_places_api_key"]
     @yahoo_api = ENV['YAHOO_API_KEY'] || @config["yahoo_api_key"]
-    end
+    @slack_incoming_webhook = ENV['slack_incoming_webhook'] || @config["slack_incoming_webhook"]
+  end
   def naive_respond(params, options = {})
     return nil if params[:user_name] == "slackbot" || params[:user_id] == "USLACKBOT"
 

--- a/Swimmy.rb
+++ b/Swimmy.rb
@@ -71,3 +71,9 @@ post '/slack' do
     slackbot.help_respond(params, username: "swimmy")
   end
 end
+
+post '/webhook/git/issue' do
+    #SYBot
+    content_type :json
+    slackbot.git_webhook_respond(params, username: "swimmy")
+end

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -3,3 +3,4 @@ google_places_api_key: XXXX
 yahoo_api_key: XXXX
 git_username: XXXX
 git_password: XXXX
+slack_incoming_webhook: XXXX


### PR DESCRIPTION
get issue を使ったときの出力について，リンクをタイトル文字列に埋め込むよう修正しました．
(2018/6/13加筆)GitHubのwebhookを用いて，issueに関して以下のアクションが生じた場合に，slackへその旨を投稿する機能をSYBotに追加しました．
1.open
2.reopen
3.close
4.assign
5.unassign
6.edit