### PR TITLE
Add base class to inherit SlackRubyBot::Command::Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,6 @@ attic/
 ################
 ## Private settings
 
-settings.yml
+.env
 vendor/
 .bundle/

--- a/lib/swimmy/command/base.rb
+++ b/lib/swimmy/command/base.rb
@@ -1,0 +1,8 @@
+require "slack-ruby-bot"
+
+module Swimmy
+  module Command
+    class Base < SlackRubyBot::Commands::Base
+    end
+  end
+end

--- a/lib/swimmy/command/hide_defalts.rb
+++ b/lib/swimmy/command/hide_defalts.rb
@@ -1,6 +1,8 @@
+require 'base'
+
 module Swimmy
     module Command
-      class Unknown < SlackRubyBot::Commands::Base
+      class Unknown < Swimmy::Command::Base
         match(/^(?<bot>\S*)[\s]*(?<expression>.*)$/)
   
         def self.call(client, data, _match)
@@ -8,7 +10,7 @@ module Swimmy
         end
       end
   
-      class About < SlackRubyBot::Commands::Base
+      class About < Swimmy::Command::Base
         command 'about', 'hi', 'help' do |client, data, match|
         end
       end

--- a/lib/swimmy/command/issue_operation.rb
+++ b/lib/swimmy/command/issue_operation.rb
@@ -9,26 +9,28 @@ require 'json'
 require 'uri'
 require 'net/https'
 require 'slack-ruby-bot'
+require 'base'
 
 GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
 
 module Swimmy
   module Command
-    class Issue_operation < SlackRubyBot::Commands::Base
+    class Issue_operation < Swimmy::Command::Base
       match(/(get|make) issue/) do |client, data, match|
         json = {:user_name => data.user, :text => data.text}.to_json
         params = JSON.parse(json, symbolize_names: true)
-        res = issue_respond(params)
+        res = Issue_operation.new.send(:issue_respond, params)
         text = JSON.parse(res)
         client.say(channel: data.channel, text: text["text"])
       end
 
-      @git_username = ENV['GIT_USERNAME']
-      @git_password = ENV['GIT_PASSWORD']
-
-      def self.issue_respond(params,options = {})
+      private
+      def issue_respond(params,options = {})
         return nil if params[:user_name] == "slackbot" || params[:user_id] == "USLACKBOT"
         text=params[:text]
+
+        git_username = ENV['GIT_USERNAME']
+        git_password = ENV['GIT_PASSWORD'] 
         # text.slice!(0..6)
         crud = issue_com_dic(text)
 
@@ -58,7 +60,7 @@ module Swimmy
           end
 
         when "c" then
-          new_issue = {:title => "default",:body => "Not edited yet\(created by Swimmy\)",:assignee => @git_username}
+          new_issue = {:title => "default",:body => "Not edited yet\(created by Swimmy\)",:assignee => git_username}
           if (i1 = text.index("t:",crud[1] + "make issue".size)) != nil then
             if (i2 = text.index("b:",i1+2)) != nil then
               new_issue["title"] = text[i1+2...i2-1]
@@ -85,7 +87,7 @@ module Swimmy
         return ret
       end
 
-      def self.issue_com_dic(str)
+      def issue_com_dic(str)
         if (crud=str.match(/get issue/)) != nil
           return ["r",0]
         elsif (i = str.index("make issue")) != nil
@@ -95,10 +97,12 @@ module Swimmy
         end
       end
 
-      def self.get_issues
+      def get_issues
+        git_username = ENV['GIT_USERNAME']
+        git_password = ENV['GIT_PASSWORD'] 
         uri = URI.parse(GITHUB_API)
         request = Net::HTTP::Get.new(uri)
-        request.basic_auth(@git_username, @git_password)
+        request.basic_auth(git_username, git_password)
         req_options = {use_ssl: uri.scheme == "https"}
         response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
           http.request(request)
@@ -106,10 +110,12 @@ module Swimmy
         return JSON.parse(response.body)
       end
 
-      def self.make_issue(issue)
+      def make_issue(issue)
+        git_username = ENV['GIT_USERNAME']
+        git_password = ENV['GIT_PASSWORD'] 
         uri = URI.parse(GITHUB_API)
         request = Net::HTTP::Post.new(uri)
-        request.basic_auth(@git_username, @git_password)
+        request.basic_auth(git_username, git_password)
         request.body = issue.to_json
         req_options = {use_ssl: uri.scheme == "https"}
         response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
@@ -118,13 +124,13 @@ module Swimmy
         return JSON.parse(response.body)["message"]
       end
 
-      def self.make_link(url,label)
+      def make_link(url,label)
         titles = "\<"
         titles << url << "\|" << label << "\>"
         return titles
       end
 
-      def self.git_webhook_respond(payloads,options = {})
+      def git_webhook_respond(payloads,options = {})
         params = JSON.parse(payloads[:payload])
         if (params == nil || params == {})then
           ret = {:text => "Faild to get action"}.merge(options).to_json
@@ -177,7 +183,7 @@ module Swimmy
         return ret
       end
     
-      def self.https_post(url,json_data)
+      def https_post(url,json_data)
         uri = URI.parse(url)
         request = Net::HTTP::Post.new(uri)
         request.body = json_data

--- a/lib/swimmy/command/issue_operation.rb
+++ b/lib/swimmy/command/issue_operation.rb
@@ -15,22 +15,23 @@ GITHUB_API = "https://api.github.com/repos/nomlab/nompedia/issues"
 
 module Swimmy
   module Command
-    class Issue_operation < Swimmy::Command::Base
+    class Issue_operation_match < Swimmy::Command::Base
       match(/(get|make) issue/) do |client, data, match|
         json = {:user_name => data.user, :text => data.text}.to_json
         params = JSON.parse(json, symbolize_names: true)
-        res = Issue_operation.new.send(:issue_respond, params)
+        res = Issue_operation.new.issue_respond(params)
         text = JSON.parse(res)
         client.say(channel: data.channel, text: text["text"])
       end
+    end
 
-      private
+    class Issue_operation
       def issue_respond(params,options = {})
         return nil if params[:user_name] == "slackbot" || params[:user_id] == "USLACKBOT"
         text=params[:text]
 
         git_username = ENV['GIT_USERNAME']
-        git_password = ENV['GIT_PASSWORD'] 
+        git_password = ENV['GIT_PASSWORD']
         # text.slice!(0..6)
         crud = issue_com_dic(text)
 
@@ -87,6 +88,7 @@ module Swimmy
         return ret
       end
 
+      private
       def issue_com_dic(str)
         if (crud=str.match(/get issue/)) != nil
           return ["r",0]

--- a/lib/swimmy/command/rain_information.rb
+++ b/lib/swimmy/command/rain_information.rb
@@ -18,17 +18,17 @@ require 'base'
 
 module Swimmy
   module Command
-    class Rain_information < Swimmy::Command::Base
+    class Rain_information_match < Swimmy::Command::Base
       match(/雨の状況/) do |client, data, match|
         json = {:user_name => data.user, :text => data.text}.to_json
         params = JSON.parse(json, symbolize_names: true)
-        res = Rain_information.new.send(:rain_info, params)
+        res = Rain_information.new.rain_info(params)
         text = JSON.parse(res)
         client.say(channel: data.channel, text: text["text"])
       end
+    end
 
-
-
+    class Rain_information
       private
       def get_locate(params)
         place_info = params[:text].sub(/の雨の状況.*/,'').sub(/.* /,'').sub(/\n/,'')
@@ -47,6 +47,27 @@ module Swimmy
         return  lng + ',' + lat
       end
 
+      def rain_power(info)
+        if info == 0 
+          return "降っていない"
+        elsif info < 10 
+          return "雨"
+        elsif info < 20 
+          return "やや強い雨"
+        elsif info < 30 
+          return "強い雨"
+        elsif info < 50 
+          return "激しい雨"
+        elsif info < 80 
+          return "非常に激しい雨"
+        elsif info >= 80
+          return "猛烈な雨"
+        else
+          return "error"
+        end
+      end
+
+      public
       def rain_info(params,options = {})
         yahoo_api = ENV['YAHOO_API_KEY']
         text = ""
@@ -85,27 +106,6 @@ module Swimmy
         end
 
         return {text: "#{text}"}.merge(options).to_json
-      end
-
-
-      def rain_power(info)
-        if info == 0 
-          return "降っていない"
-        elsif info < 10 
-          return "雨"
-        elsif info < 20 
-          return "やや強い雨"
-        elsif info < 30 
-          return "強い雨"
-        elsif info < 50 
-          return "激しい雨"
-        elsif info < 80 
-          return "非常に激しい雨"
-        elsif info >= 80
-          return "猛烈な雨"
-        else
-          return "error"
-        end
       end
     end
   end

--- a/lib/swimmy/command/restaurant_information.rb
+++ b/lib/swimmy/command/restaurant_information.rb
@@ -17,15 +17,17 @@ BASE_URL_PHOTO = "https://maps.googleapis.com/maps/api/place/photo?"
 
 module Swimmy
   module Command
-    class Restaurant_information < Swimmy::Command::Base
+    class Restaurant_information_match < Swimmy::Command::Base
       match(/の情報/) do |client, data, match|
         json = {:user_name => data.user, :text => data.text}.to_json
         p params = JSON.parse(json, symbolize_names: true)
-        res = Restaurant_information.new.send(:show_place_detail, params)
+        res = Restaurant_information.new.show_place_detail(params)
         text = JSON.parse(res)
         client.say(channel: data.channel, text: text["text"])
       end
+    end
 
+    class Restaurant_information 
       private
       # get place info by text search
       def get_place_info(keyword)
@@ -143,6 +145,7 @@ module Swimmy
         return photo_url
       end
 
+      public
       # show detail info about certain place
       def show_place_detail(params, options = {})
         query_str = params[:text]

--- a/lib/swimmy/command/route.rb
+++ b/lib/swimmy/command/route.rb
@@ -16,20 +16,23 @@ BASE_URL_DIRECTIONS = "https://maps.googleapis.com/maps/api/directions/json"
 
 module Swimmy
   module Command
-    class Route < Swimmy::Command::Base
+    class Route_match < Swimmy::Command::Base
       match(/.*での.*から.*までの道/) do |client, data, match|
         json = {:user_name => data.user, :text => data.text}.to_json
         params = JSON.parse(json, symbolize_names: true)
-        res = Route.new.send(:distance_respond, params)
+        res = Route.new.distance_respond(params)
         text = JSON.parse(res)
         client.say(channel: data.channel, text: text["text"])
       end
+    end
 
+    class Route
       private
       def address_to_geocode(address)
         google_maps_api = ENV['GOOGLE_MAPS_API_KEY']
         address = URI.encode(address)
         hash = Hash.new
+
         reqUrl = "#{BASE_URL_GEOCODE}?address=#{address}&sensor=false&language=ja&key=" + google_maps_api
 
         response = Net::HTTP.get_response(URI.parse(reqUrl))
@@ -93,6 +96,7 @@ module Swimmy
         return hash
       end
 
+      public
       def distance_respond(params, options = {})
         return nil if params[:user_name] == "slackbot" || params[:user_id] == "USLACKBOT"
         address = params[:text].match(/.*での(.*)から(.*)までの道/)
@@ -120,4 +124,3 @@ module Swimmy
     end
   end
 end
-


### PR DESCRIPTION
変更点は以下である．
- 各コマンドは SlackRubyBot::Command::Base を継承していた．これを，SlackRubyBot::Command::Base を継承する Base クラスを作成し，各コマンドは Base クラスを継承するように書き換えた．
- 各コマンドの public メソッドを，すべて private メソッドに変更した．
- .env ファイルを .gitignore に追加して，git の管理に含めないようにした．
