### PR TITLE
Add poll command

### DIFF
--- a/lib/swimmy/command.rb
+++ b/lib/swimmy/command.rb
@@ -7,6 +7,7 @@ module Swimmy
     require "#{dir}/rain_information"
     require "#{dir}/restaurant_information"
     require "#{dir}/route"
+    require "#{dir}/poll"
   # require "#{dir}/hide_defalts"
   end
 end

--- a/lib/swimmy/command/poll.rb
+++ b/lib/swimmy/command/poll.rb
@@ -1,0 +1,85 @@
+# coding: utf-8
+#
+# Hiromu Ishikawa / nomlab
+# Yutaro Takaie / nomlab
+# This is a part of https://github.com/nomlab/swimmy
+#
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
+require 'json'
+require 'uri'
+require 'net/https'
+require 'slack-ruby-bot'
+require 'base'
+
+$emoji_list = [[":one:",:one], [":two:",:two],[":three:",:three],[":four:",:four],[":five:",:five],[":six:",:six],[":seven:",:seven],[":eight:",:eight],[":nine:",:nine]]
+$poll = {ts: 0, title: "", choices: [], count: []}
+
+module Swimmy
+  module Command
+    class PollMatch < Swimmy::Command::Base
+      match(/poll/) do |client, data, match|
+        json = {:user_name => data.user, :text => data.text}.to_json
+        params = JSON.parse(json, symbolize_names: true)
+        res = Poll.new.response(params)
+        text = JSON.parse(res)
+        client.say(channel: data.channel, text: text["text"])
+        # channels.history という API を用いるためには，ユーザ用の token に切り替える必要がある．
+        client.web_client.token = ENV["SLACK_API_TOKEN_USER"]
+        # 最新の message を channels.history で取得する際，bot の発言が反映されない場合があるため，0.5 秒待つ．検討の余地あり．
+        sleep(0.5)
+        $poll[:ts] = client.web_client.channels_history(channel: data.channel)["messages"][0]["ts"]
+        client.web_client.token = client.token
+        $poll[:choices].each_with_index do |choice, i|
+          client.web_client.reactions_add(name: $emoji_list[i][1], channel: data.channel, timestamp: $poll[:ts])
+        end
+
+      end
+    end
+
+    class PollCounter < SlackRubyBot::Server
+      on 'reaction_added' do |client, data|
+        p data
+        if data.item.ts == $poll[:ts] and data.item_user != data.user
+          reaction_idx = $emoji_list.index([(":"+data.reaction+":"), data.reaction.intern])
+          $poll[:count][reaction_idx] += 1
+          text = "「#{$poll[:title]}」について集計します!\n以下の選択肢に対応するスタンプを選択してください．\n"
+          $poll[:choices].each_with_index do |choice, i|
+            text += "#{$emoji_list[i][0]}：#{choice} #{$poll[:count][i]}\n"
+          end
+          client.web_client.chat_update(channel: data.item.channel, ts: $poll[:ts], text: text)
+        end
+      end
+
+      on 'reaction_removed' do |client, data|
+        p data
+        if data.item.ts == $poll[:ts] and data.item_user != data.user
+          reaction_idx = $emoji_list.index([(":"+data.reaction+":"), data.reaction.intern])
+          $poll[:count][reaction_idx] -= 1
+          text = "「#{$poll[:title]}」について集計します!\n以下の選択肢に対応するスタンプを選択してください．\n"
+          $poll[:choices].each_with_index do |choice, i|
+            text += "#{$emoji_list[i][0]}：#{choice} #{$poll[:count][i]}\n"
+          end
+          client.web_client.chat_update(channel: data.item.channel, ts: $poll[:ts], text: text)
+        end
+      end
+    end
+
+    class Poll
+      def response(params, options = {})
+        query_str = params[:text]
+        query_str = query_str.match(/poll (.*) (.*)/)
+        $poll[:title] = query_str[1]
+        $poll[:choices] = query_str[2].split(",")
+        $poll[:choices].each do |choice|
+          $poll[:count].push(0)
+        end
+        res_text = "「#{$poll[:title]}」について集計します!\n以下の選択肢に対応するスタンプを選択してください．\n"
+        $poll[:choices].each_with_index do |choice, i|
+          res_text += "#{$emoji_list[i][0]}：#{choice} #{$poll[:count][i]}\n"
+        end
+        return {text: res_text}.merge(options).to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 内容
swimmy に投票機能を追加した．タイトルと選択肢を指定すると，slack のリアクションを用いた投票用メッセージが swimmy から送信される．
投票機能を利用するためには，以下に示す形式のメッセージを送信する．
`poll 投票の題目 選択肢1,選択肢2,...` 
例を以下に示す．
`poll 忘年会の出欠 参加,不参加`
適切なメッセージを送信したとき，swimmy から以下のようなメッセージが送信される．

![image](https://user-images.githubusercontent.com/15909860/50325045-e545da80-0525-11e9-8867-61a3657c95a4.png)

投票したい番号に対応するリアクションをクリックすることで，投票でき，投票数がリアルタイムで更新される．

### トークンの切り替えについて
poll コマンドでは，リアクションをつける際，channel.history という API を利用している．
channel.history は，Bot 用の API トークンではなく，User 用の API トークンを用いる必要がある．
そこで，現在，poll コマンド内では，channel.history を用いるときに，一時的にトークンを切り替えている．
また，poll コマンドでは，各種 API トークンを記述する，`.env` というファイルに `SLACK_API_TOKEN_USER` というキーで User用の API トークンが記述されていることを想定している．