### PR TITLE
Add restart command and hello option

### DIFF
--- a/exe/swimmy
+++ b/exe/swimmy
@@ -28,6 +28,7 @@ Thread.abort_on_exception = true
 require "rubygems"
 require "swimmy"
 require "dotenv"
+require "optparse"
 
 Dotenv.load
 
@@ -45,6 +46,11 @@ env_names.each do |env_name|
 end
 
 exit 1 if error_count > 0
+
+opt_hello = nil
+option = OptionParser.new
+option.on('--hello ITEM', 'say hello') { |v| opt_hello = v }
+option.parse(ARGV)
 
 # 以下のよう run を使うと client オブジェクトのの後始末をしてくれたり，
 # 再接続を試みたりしてくれて，嬉しいのだけど，内部で実装されている再接
@@ -69,10 +75,11 @@ exit 1 if error_count > 0
 #
 # 今のところ，とりあえず，当初の物に戻しておく↓
 #
+
 loop do
   begin
     bot = Swimmy::App.new(token: ENV["SLACK_API_TOKEN"],
-                          spreadsheet: ENV["SWIMMY_SHEET_ID"])
+                          spreadsheet: ENV["SWIMMY_SHEET_ID"], hello: opt_hello)
     bot.start!
 
   rescue Interrupt, SignalException => e

--- a/lib/swimmy/app.rb
+++ b/lib/swimmy/app.rb
@@ -58,9 +58,11 @@ module Swimmy
   ## Main app
   class App < SlackRubyBot::Server
     on "hello" do |client, data|
-      opt = OptionParser.new
-      opt.on('--hello ITEM', 'say hello') { |v| client.say(channel: ENV["POST_CHANNEL"], text: "#{v}") }
-      opt.parse(ARGV)
+      begin
+        client.say(channel: @@channel, text: @@msg)
+      rescue => e
+        puts e
+      end
     end
 
     def initialize(opt)
@@ -68,6 +70,12 @@ module Swimmy
         Swimmy::Command.spreadsheet =
           initialize_spreadsheet(opt[:spreadsheet])
         opt.delete(:spreadsheet)
+      end
+
+      if opt[:hello]
+        hello = opt[:hello].split(':')
+        initialize_hello(hello[0], hello[1])
+        opt.delete(:hello)
       end
 
       super(opt)
@@ -94,5 +102,11 @@ module Swimmy
       return Sheetq::Service::Spreadsheet.new(client, spreadsheet_id)
     end
 
+    def initialize_hello(channel, msg)
+      @@channel = channel
+      @@msg = msg
+    end
+
   end # class App
 end # module Swimmy
+

--- a/lib/swimmy/app.rb
+++ b/lib/swimmy/app.rb
@@ -13,6 +13,7 @@
 
 # require "celluloid"
 require "slack-ruby-bot"
+require "optparse"
 
 module Swimmy
   ## Ping thread to maintain connections
@@ -56,6 +57,11 @@ module Swimmy
 
   ## Main app
   class App < SlackRubyBot::Server
+    on "hello" do |client, data|
+      opt = OptionParser.new
+      opt.on('--hello ITEM', 'say hello') { |v| client.say(channel: ENV["POST_CHANNEL"], text: "#{v}") }
+      opt.parse(ARGV)
+    end
 
     def initialize(opt)
       if opt[:spreadsheet]

--- a/lib/swimmy/command/restart.rb
+++ b/lib/swimmy/command/restart.rb
@@ -13,7 +13,7 @@ module Swimmy
 
         begin
           exe_file = Dir::pwd + "/exe/swimmy"
-          exec("bundle exec #{exe_file} --hello 再起動完了!")
+          exec("bundle exec #{exe_file} --hello #{data.channel}:再起動完了!")
         rescue => e
           client.say(channel: data.channel, text: "再起動に失敗しました．")
           raise e

--- a/lib/swimmy/command/restart.rb
+++ b/lib/swimmy/command/restart.rb
@@ -12,7 +12,13 @@ module Swimmy
         client.say(channel: data.channel, text: "再起動します")
 
         begin
-          exe_file = Dir::pwd + "/exe/swimmy"
+          exe_command = $0
+          if exe_command.start_with?('/')
+            exe_file = exe_command
+          else
+            exe_file = Dir::pwd + "/#{exe_command}"
+          end
+
           exec("bundle exec #{exe_file} --hello #{data.channel}:再起動完了!")
         rescue => e
           client.say(channel: data.channel, text: "再起動に失敗しました．")

--- a/lib/swimmy/command/restart.rb
+++ b/lib/swimmy/command/restart.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+#
+# Restart swimmy system
+#
+
+module Swimmy
+  module Command
+    class Restart < Swimmy::Command::Base
+
+      command "restart" do |client, data, match|
+        puts client.class
+        client.say(channel: data.channel, text: "再起動します")
+
+        begin
+          exe_file = Dir::pwd + "/exe/swimmy"
+          exec("bundle exec #{exe_file} --hello 再起動完了!")
+        rescue => e
+          client.say(channel: data.channel, text: "再起動に失敗しました．")
+          raise e
+        end
+      end
+
+      help do
+        title "restart"
+        desc "swimmyを再起動します．"
+        long_desc "swimmyを再起動します．引数はありません．"
+      end
+
+    end # class Restart
+  end # module Command
+end # module Swimmy


### PR DESCRIPTION
#45 と #56 に対するPRである．

## やったこと
swimmy の再起動をSlackからできるようにするための機能を追加した．
具体的には，以下を行なった．
+ `lib/swimmy/command` に`restart.rb`を作成し，Slackからrestartコマンドを実行すると再起動するようにした．
+ `lib/swimmy/app.rb` にswimmyを起動する際のオプションを追加し，swimmy起動時に，指定したメッセージがSlackに投稿されるようにした．

### 起動時のメッセージの指定方法
swimmy起動時に，指定したメッセージをSlackに投稿する方法の例を以下に示す．
```
$ bundle exec exe/swimmy --hello 起動しました！
```
