### PR TITLE
Change Actions trigger from push to pull-request

### DIFF
--- a/.github/workflows/swimmy.yml
+++ b/.github/workflows/swimmy.yml
@@ -10,16 +10,21 @@
 name: build
 
 on:
-  push:
-    branches: [ master ]
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize]
+
 
 jobs:
-  test:
+  RSpec-test:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
#46 に関するPR

GitHub Actionsのワークフローをトリガするイベントをpushからpull-requestに変更

