### PR TITLE
メッセージ分割のタイミングを変更した．また，expand_pathで絶対パスを指定するようにした．

### DIFF
--- a/lib/swimmy/app.rb
+++ b/lib/swimmy/app.rb
@@ -58,18 +58,17 @@ module Swimmy
   class App < SlackRubyBot::Server
     on "hello" do |client, data|
       begin
-        ch = CHANNEL_QUEUE.shift
-        msg = MESSAGE_QUEUE.shift
+        message = MESSAGE_QUEUE.shift
+        ch, post_msg = message.split(':', 2)
         if ch.start_with?("#")
           ch = client.web_client.channels_info(channel: ch).channel.id
         end
-        client.say(channel: ch, text: msg)
+        client.say(channel: ch, text: post_msg)
       rescue => e
         puts e
       end
     end
 
-    CHANNEL_QUEUE = []
     MESSAGE_QUEUE = []
     def initialize(opt)
       if opt[:spreadsheet]
@@ -79,8 +78,7 @@ module Swimmy
       end
 
       if opt[:hello]
-        ch, msg = opt[:hello].split(':', 2)
-        initialize_hello(ch, msg)
+        MESSAGE_QUEUE << opt[:hello]
         opt.delete(:hello)
       end
 
@@ -108,10 +106,6 @@ module Swimmy
       return Sheetq::Service::Spreadsheet.new(client, spreadsheet_id)
     end
 
-    def initialize_hello(channel, msg)
-      CHANNEL_QUEUE << channel
-      MESSAGE_QUEUE << msg
-    end
 
   end # class App
 end # module Swimmy

--- a/lib/swimmy/command/restart.rb
+++ b/lib/swimmy/command/restart.rb
@@ -9,13 +9,12 @@ module Swimmy
 
       command "restart" do |client, data, match|
         client.say(channel: data.channel, text: "再起動します")
-        begin
           exe_file = File.expand_path($0)
-          exec("bundle exec #{exe_file} --hello #{data.channel}:再起動完了!")
-        rescue => e
-          client.say(channel: data.channel, text: "再起動に失敗しました．")
-          raise e
-        end
+          if File.exist?(exe_file)
+            exec("bundle exec #{exe_file} --hello #{data.channel}:再起動完了!")
+          else
+            client.say(channel: data.channel, text: "再起動に失敗しました．")
+          end
       end
 
       help do

--- a/lib/swimmy/command/restart.rb
+++ b/lib/swimmy/command/restart.rb
@@ -8,17 +8,9 @@ module Swimmy
     class Restart < Swimmy::Command::Base
 
       command "restart" do |client, data, match|
-        puts client.class
         client.say(channel: data.channel, text: "再起動します")
-
         begin
-          exe_command = $0
-          if exe_command.start_with?('/')
-            exe_file = exe_command
-          else
-            exe_file = Dir::pwd + "/#{exe_command}"
-          end
-
+          exe_file = File.expand_path($0)
           exec("bundle exec #{exe_file} --hello #{data.channel}:再起動完了!")
         rescue => e
           client.say(channel: data.channel, text: "再起動に失敗しました．")


### PR DESCRIPTION
#45 #56 へのPRである．

以下の議事録の内容に基づいて，変更を行った．
+ swimmyが再接続された場合にも起動メッセージが表示されるため，メッセージをキューで管理することで，起動時の1回のみ表示されるようにした．
+ “exe/swimmy”へのパスがプログラム中に埋め込まれているため，“$0”を用いて実行ファイルを指定するようにした．
+ 絶対パスを使うときはexpand_pathを使うと良い．
+ $0が存在するかをチェックする必要がある．
+ 1つのキューに入れて，キューから取り出した際にスプリットした方が良い．

変更内容は，以下の通りである．
+ `lib/swimmy/command/restart.rb`について
  + expand_pathを使って実行ファイルの絶対パスを出すようにした．
  + $0が存在するかどうかを確認するようにした．
+ `lib/swimmy/app.rb`について
  + helloオプションのメッセージをキューから取り出した後にチャンネル名と表示したい文字列に分割するようにした．