### PR TITLE
Modify update command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'async-websocket', '~>0.8.0'
 gem 'google-api-client', "~> 0.8"
 gem 'sheetq', :git => 'https://github.com/nomlab/sheetq.git'
 gem 'rspec'
+gem 'systemu'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       gli
       hashie
       websocket-driver
+    systemu (2.6.5)
     thor (1.0.1)
     thread_safe (0.3.6)
     timers (4.3.0)
@@ -135,6 +136,7 @@ DEPENDENCIES
   sheetq!
   slack-ruby-bot
   swimmy!
+  systemu
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
#78 に対するPR

1. when update failed, swimmy send error message to slack
2. if no change, swimmy notify that already up to date
3. add --ff-only option to "git pull" command