### PR TITLE
Add now command

### DIFF
--- a/lib/swimmy/command/now.rb
+++ b/lib/swimmy/command/now.rb
@@ -1,0 +1,59 @@
+# coding: utf-8
+module Swimmy
+  module Command
+    class Now < Swimmy::Command::Base
+
+      command "now","117" do |client, data, match|
+        client.say(channel: data.channel, text: TimeSignalFormatter.new.format(Time.now))  
+      end
+    
+      help do
+        title "now"
+        desc "現在の日時についての様々な情報を発言します"
+        long_desc "現在の日時についての情報（日付，時刻，和暦，第n曜日,記念日）を発言します．引数はありません"
+      end
+
+      ################################################################
+      ## private inner class
+
+      class TimeSignalFormatter
+        DAYS = ["日","月","火","水","木","金","土"]
+        OFFSET_LATEST_ERA = 2018
+        LATEST_ERA = "令和"
+        NOT_EXIST_ANNIVERSARIES = "記念日なし"
+
+        def format(time)
+
+          wday = DAYS[time.wday]
+          wareki = time.year - OFFSET_LATEST_ERA
+          anniversaries = anniversary_service.get_anniversay_event_titles_by_time(time)
+
+          anniversaries_text = anniversaries.empty? ? NOT_EXIST_ANNIVERSARIES : anniversaries.join('，')
+
+          message = "---------------時報---------------\n" +
+                    time.strftime("%Y年%m月%d日（#{wday}）\n") +
+                    time.strftime("%H時%M分\n") +
+                    "\n" +
+                    "今年は#{LATEST_ERA}#{wareki}年\n" +
+                    "今日は第#{num_of_wday(time)}#{wday}曜日\n" + 
+                    "\n" +
+                    "今日の記念日：#{anniversaries_text}\n" +
+                    "----------------------------------\n"
+
+          message
+        end
+
+        def num_of_wday(time)
+          time.day / DAYS.length + 1
+        end
+
+        def anniversary_service
+          Service::Anniversary.new
+        end
+
+      end
+
+    end # class Now
+
+  end # module Command
+end # module Swimmy

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -8,5 +8,6 @@ module Swimmy
     autoload :Weather,     "#{dir}/weather.rb"
     autoload :Member,      "#{dir}/member.rb"
     autoload :Calendar,    "#{dir}/calendar.rb"
+    autoload :Anniversary, "#{dir}/anniversary.rb"
   end
 end

--- a/lib/swimmy/resource/anniversary.rb
+++ b/lib/swimmy/resource/anniversary.rb
@@ -1,0 +1,20 @@
+module Swimmy
+    module Resource
+      class Anniversary
+        attr_reader :month, :day, :title
+  
+        def initialize(month, day, title)
+          @month, @day, @title = month, day, title
+        end
+
+        def occur_on?(date_or_time)
+          date_or_time.strftime('%-m') == @month && date_or_time.strftime('%-d') == @day
+        end
+
+        def ==(obj)
+          @month == obj.month && @day == obj.day && obj.title
+        end
+  
+      end # class Anniversary
+    end # module Resource
+  end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -4,5 +4,6 @@ module Swimmy
 
     autoload :Geocoding,   "#{dir}/geocoding.rb"
     autoload :Weather,     "#{dir}/weather.rb"
+    autoload :Anniversary, "#{dir}/anniversary.rb"
   end
 end

--- a/lib/swimmy/service/anniversary.rb
+++ b/lib/swimmy/service/anniversary.rb
@@ -1,0 +1,31 @@
+module Swimmy
+    module Service
+      class Anniversary
+
+        # API仕様：https://www.mediawiki.org/wiki/API:Main_page
+        WIKIPEDIA_URI = "https://ja.wikipedia.org/w/api.php?format=json&action=query&prop=revisions&pageids=456328&rvprop=content"
+
+        def get_anniversay_event_titles_by_time(time)
+          fetch_annual_anniversary_events
+            .filter{ |it| it.occur_on?(time) }
+            .map{ |it| it.title }
+        end
+
+        def fetch_annual_anniversary_events
+          anniversaries = JSON.parse(URI.open(WIKIPEDIA_URI, &:read))["query"]["pages"]["456328"]["revisions"][0]["*"]
+
+          parse_annual_anniversary_events(anniversaries)
+        end
+
+        def parse_annual_anniversary_events(anniversaries)
+          anniversaries.scan(/^\*[^\d]*(\d+)\s*月[^\d]*(\d+)日[^-]*- (.*)/)
+            .map{ |month, day, titles|
+              titles.gsub(/[\[\]]/, "").split(/, /).map{ |title|
+                Resource::Anniversary.new(month, day, title)
+              }
+            }.flatten
+        end
+        
+      end # class Anniversary
+    end # module Service
+  end # module Swimmy

--- a/spec/now_spec.rb
+++ b/spec/now_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe Swimmy::Service::Anniversary do
+    anniversary = Swimmy::Service::Anniversary.new
+    dummy_parsed = Array.new([
+        Swimmy::Resource::Anniversary.new("1", "1", "あ"),
+        Swimmy::Resource::Anniversary.new("1", "2", "い"),
+        Swimmy::Resource::Anniversary.new("1", "2", "う")
+    ])
+    it "hit a anniversary" do
+        allow(anniversary).to receive(:fetch_annual_anniversary_events).and_return(dummy_parsed)
+
+        expect(
+            anniversary.get_anniversay_event_titles_by_time(Time.parse("1/1"))
+        ).to eq(Array.new(["あ"]))
+    end
+
+    it "hit multiple anniversaries" do
+        allow(anniversary).to receive(:fetch_annual_anniversary_events).and_return(dummy_parsed)
+
+        expect(
+            anniversary.get_anniversay_event_titles_by_time(Time.parse("1/2"))
+        ).to eq(Array.new(["い","う"]))
+    end
+
+    it "hit no anniversaries" do
+        allow(anniversary).to receive(:fetch_annual_anniversary_events).and_return(dummy_parsed)
+
+        expect(
+            anniversary.get_anniversay_event_titles_by_time(Time.parse("1/3"))
+        ).to eq(Array.new())
+    end
+
+    it "parse a anniversary" do
+        dummy_fetched = "* [[1月1日|{{0}}1日]] - あ"
+        expect(
+            anniversary.parse_annual_anniversary_events(dummy_fetched)
+        ).to eq(Array.new([Swimmy::Resource::Anniversary.new("1", "1", "あ")]))
+    end
+
+    it "parse multiple anniversaries" do
+        dummy_fetched = "* [[1月1日|{{0}}1日]] - あ, い"
+        expect(
+            anniversary.parse_annual_anniversary_events(dummy_fetched)
+        ).to eq(Array.new([
+            Swimmy::Resource::Anniversary.new("1", "1", "あ"), 
+            Swimmy::Resource::Anniversary.new("1", "1", "い")
+            ]))
+    end
+
+    it "parse included link anniversary" do
+        dummy_fetched = "* [[1月1日|{{0}}1日]] - [[あ]]"
+        expect(
+            anniversary.parse_annual_anniversary_events(dummy_fetched)
+        ).to eq(Array.new([Swimmy::Resource::Anniversary.new("1", "1", "あ")]))
+    end
+
+
+end


### PR DESCRIPTION
## TL;DR

- 時報+αを表示する`now`コマンド（`117`コマンド）の実装

## 実装目的

- 乃村研のB4向け新人研修に取り組むため
  -  [新人研修課題](https://scrapbox.io/nompedia/swimmy_%E3%81%AE%E6%A9%9F%E8%83%BD%E8%BF%BD%E5%8A%A0)

## 使い方
`/swimmy [now|117]/` と入力し，時報を表示する

<img width="708" alt="スクリーンショット 2021-04-04 15 31 08" src="https://user-images.githubusercontent.com/25548427/113500667-c931a000-955a-11eb-9647-cde2b28ea758.png">

## 実装内容

- 日時のデータを受け取り，その日が何の記念日かを取得する機能
   - wikipedia の API を使用しました https://www.mediawiki.org/wiki/API:Main_page
   - ほぼスクレイピングのようなものなので， wikipedia 側のレイアウト変更には弱いです（正規表現である程度柔軟性は持たせています）
   - https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC%E3%81%AE%E8%A8%98%E5%BF%B5%E6%97%A5%E4%B8%80%E8%A6%A7 のページの内容を取得
 
- ↑で生成した文字列を Slack 上に通知する機能
