### PR TITLE
Add "tide.rb & tide_spec.rb"

### DIFF
--- a/lib/swimmy/command/tide.rb
+++ b/lib/swimmy/command/tide.rb
@@ -1,0 +1,91 @@
+# coding: utf-8
+
+require "date"
+require "json"
+require "open-uri"
+
+module Swimmy
+  module Command
+    class Tide < Swimmy::Command::Base
+      
+      command "tide" do |client, data, match|
+        client.say(channel: data.channel, text: TideDataMessage.new.create_mes(match[:expression]))
+      end #end "command"
+
+      help do
+        title "tide"
+        desc "牛窓の潮の情報を教えます"
+        long_desc "tide - 今日の牛窓の潮の情報を教えます\n" +
+                  "tide YYYY-MM-DD - YYYY年MM月DD日の牛窓の潮の情報を教えます\n" +
+                  "tide MM-DD - #{Date.today.year}年MM月DD日の牛窓の潮の情報を教えます\n"
+      end #end "help"
+
+      class TideDataMessage
+
+        def parse2date(date_string)
+          return Date.today unless date_string
+          if date_string =~ /(\d+)-(\d+)(-(\d+))?/
+            y, m, d = [$1, $2, $4].map(&:to_i) if $4
+            y, m, d = [Date.today.year, $1, $2].map(&:to_i) unless $4
+            return Date.new(y, m, d) if Date.valid_date?(y, m, d)
+          end
+          return nil
+        end #end "parse2date"
+
+        def parse2time(time_string)
+          h, m = time_string.split(":").map(&:to_i)
+          time = Time.new(1, 1, 1, h, m, 0)
+        end #end "parse2time"
+
+        def parse2str(time_ary)
+          time_ary.map{|t| t.strftime("%H:%M")}.join(", ")
+        end #end "parse2str"
+        
+        def calc_maxsp_time(edd_time, fl_time)
+          time = (edd_time + fl_time).sort
+          time.each_cons(2).map do |edd, fl|
+            t = (edd - fl) / 2
+            fl + t
+          end
+        end #end "calc_maxsp_time"
+
+        def fetch_tide_data(date)
+          tide_url = "https://tide736.net/api/get_tide.php?pc=33&hc=3&yr=#{date.year}&mn=#{date.mon}&dy=#{date.mday}&rg=day"
+          
+          data = JSON.parse(URI.open(tide_url).string)
+          date = date.strftime("%Y-%m-%d")
+          
+          harbor = data["tide"]["port"]["harbor_namej"]
+          type = data["tide"]["chart"][date]["moon"]["title"]
+          
+          edd_1 = data["tide"]["chart"][date]["edd"].first["time"]
+          edd_2 = data["tide"]["chart"][date]["edd"].last["time"]
+          flood_1 = data["tide"]["chart"][date]["flood"].first["time"]
+          flood_2 = data["tide"]["chart"][date]["flood"].last["time"]
+
+          edd = [parse2time(edd_1), parse2time(edd_2)].uniq
+          flood = [parse2time(flood_1), parse2time(flood_2)].uniq
+          
+          maxsp = calc_maxsp_time(edd, flood)
+          
+          return harbor, type, edd, flood, maxsp
+        end #end "fetch_tide_data"
+
+        def create_mes(input)
+          date = parse2date(input)
+          return "Wrong format: #{input}" unless date
+          
+          harbor, type, edd, flood, maxsp = fetch_tide_data(date)
+
+          mes = date.strftime("%Y-%m-%d") + "\n" +
+                harbor + "\n" +
+                "潮名 | " + type + "\n" +
+                "干潮 | " + parse2str(edd) + "\n" +
+                "満潮 | " + parse2str(flood) + "\n" +
+                "最高潮流時 | " + parse2str(maxsp) + "\n"
+          return mes
+        end #end "create_mes"
+      end #end "TideDataMessage"
+    end #end "Tide"
+  end #end "Command"
+end #end "Swimmy"

--- a/spec/tide_spec.rb
+++ b/spec/tide_spec.rb
@@ -1,0 +1,84 @@
+require "date"
+require "time"
+
+test_time1 = Time.new(1,1,1,7,30,0)
+test_time2 = Time.new(1,1,1,14,30,0)
+
+RSpec.describe Swimmy::Command::Tide::TideDataMessage do
+  tide = Swimmy::Command::Tide::TideDataMessage.new
+  
+  it "parse date(nil)" do
+    expect(
+      tide.parse2date(nil)
+    ).to eq(Date.today)
+  end
+
+  it "parse date(YY-MM-DD)" do
+    expect(
+      tide.parse2date("100-1-1")
+    ).to eq(Date.new(100,1,1))
+  end
+
+  it "parse date(MM-DD)" do
+    expect(
+      tide.parse2date("1-1")
+    ).to eq(Date.new(Date.today.year,1,1))
+  end
+
+  it "parse date(wrong date)" do
+    expect(
+      tide.parse2date("2021-4-40")
+    ).to eq(nil)
+  end
+
+  it "parse date(wrong text)" do
+    expect(
+      tide.parse2date("error")
+    ).to eq(nil)
+  end
+
+  it "parse time" do
+    expect(
+      tide.parse2time("01:01")
+    ).to eq(Time.new(1, 1, 1, 1, 1, 0))
+  end
+
+  it "parse str(2time)" do
+    expect(
+      tide.parse2str([test_time1, test_time2])
+    ).to eq("07:30, 14:30")
+  end
+
+  it "parse str(1time)" do
+    expect(
+      tide.parse2str([test_time1])
+    ).to eq("07:30")
+  end
+
+  it "calc maxsp(4time)" do
+    expect(
+      tide.calc_maxsp_time([test_time1, test_time2], [test_time1 + 3.hour, test_time2 + 2.hour])
+    ).to eq([Time.new(1,1,1,9,0,0),Time.new(1,1,1,12,30,0),Time.new(1,1,1,15,30,0)])
+
+    expect(
+      tide.calc_maxsp_time([test_time1 + 3.hour, test_time2 + 2.hour], [test_time1, test_time2])
+    ).to eq([Time.new(1,1,1,9,0,0),Time.new(1,1,1,12,30,0),Time.new(1,1,1,15,30,0)])
+  end
+
+  it "calc maxsp(3time)" do
+    expect(
+      tide.calc_maxsp_time([test_time1, test_time2], [test_time1 + 3.hour])
+    ).to eq([Time.new(1,1,1,9,0,0),Time.new(1,1,1,12,30,0)])
+
+    expect(
+      tide.calc_maxsp_time([test_time1 + 3.hour], [test_time1, test_time2])
+    ).to eq([Time.new(1,1,1,9,0,0),Time.new(1,1,1,12,30,0)])
+  end
+
+  it "calc maxsp(2time)" do
+    expect(
+      tide.calc_maxsp_time([test_time1], [test_time1 + 3.hour])
+    ).to eq([Time.new(1,1,1,9,0,0)])
+  end
+  
+end


### PR DESCRIPTION
## TL;DR

- 潮の情報を表示する'tide'コマンドの実装

## 実装目的

- 乃村研のB4向け新人研修に取り組むため
  -  [新人研修課題](https://scrapbox.io/nompedia/swimmy_%E3%81%AE%E6%A9%9F%E8%83%BD%E8%BF%BD%E5%8A%A0)

## 使い方
`/swimmy tide/` ， `/swimmy tide YYYY-MM-DD/` ， `/swimmy tide MM-DD/` のいずれかを入力し，潮の情報を表示する

## 実装内容

- 日時のデータを受け取り，その日の潮の情報を取得する機能
  - 潮のapiは https://tide736.net/ のものを使用しました
  - apiで取得した情報以外に最も潮の早い時間(満潮と干潮の中間)を計算し表示しています