### PR TITLE
Add stock command

### DIFF
--- a/lib/swimmy/command/stock.rb
+++ b/lib/swimmy/command/stock.rb
@@ -1,0 +1,82 @@
+# coding: utf-8
+module Swimmy
+  module Command
+    class Stock < Swimmy::Command::Base
+
+      command "stock" do |client, data, match|
+
+        case match[:expression]
+        when /(\d+)/
+          code = "#{$1.to_i}.T"
+          stock = WorkHorse.new(code)
+
+          stock.fetch
+          client.say(channel: data.channel, text: stock.message("銘柄コード#{$1.to_i}の株価"))
+        when nil
+          code = "%5EN225"
+          stock = WorkHorse.new(code)
+
+          stock.fetch
+          client.say(channel: data.channel, text: stock.message("日経平均株価"))
+        else
+          client.say(channel: data.channel, text: help_message("stock"))
+        end
+      end
+
+      help do
+        title "stock"
+        desc "今日の国内の株価を教えてくれます．"
+        long_desc "stock - 今日の日経平均株価の始値，高値，安値，終値を表示します．\n" +
+                  "stock XXXX - 銘柄コードXXXXの今日の始値，高値，安値，終値を表示します．\n"
+      end
+
+      
+      class WorkHorse
+        require 'json'
+        require 'uri'
+        require 'net/http'
+
+        def initialize(code)
+          @uri ="https://query1.finance.yahoo.com/v8/finance/chart/#{code}?range=2d&interval=1d"
+        end
+
+        def fetch
+          begin
+            parsed_uri =URI.parse(@uri)
+            request = Net::HTTP::Get.new(parsed_uri.request_uri)
+            http = Net::HTTP.new(parsed_uri.host,parsed_uri.port)
+            request['User-Agent'] = 'curl/7.64.0'
+            http.use_ssl = true
+            json = http.request(request)
+            @result = JSON.parse(json.body)
+          rescue => e
+            @result = nil
+            raise e
+          end
+        end
+
+        def message(stock_name)
+          return "Error" if @result == nil
+          begin
+            return "指定されたコードの銘柄が見つかりません．" if @result['chart']['error'] != nil
+
+            close = [ @result['chart']['result'][0]['indicators']['quote'][0]['close'][0],\
+                            @result['chart']['result'][0]['indicators']['quote'][0]['close'][1] \
+                          ]
+            index = ((close[1] == nil) ? 0:1)
+            
+            text = "今日の#{stock_name}\n" +
+                   "始値 : #{@result['chart']['result'][0]['indicators']['quote'][0]['open'][index]}\n" +
+                   "高値 : #{@result['chart']['result'][0]['indicators']['quote'][0]['high'][index]}\n" +
+                   "安値 : #{@result['chart']['result'][0]['indicators']['quote'][0]['low'][index]}\n" +
+                   "終値 : #{close[index]}\n\n" +
+                   "前日比 : #{s=(d=close[index]-close[0])<0?"":"+"}#{d.round(2)} (#{s}#{(d/close[0]*100).round(2)}%)\n"
+          rescue => e
+            return "Error"
+          end
+        end
+      end # class WorkHorse
+      private_constant :WorkHorse
+    end # class Stock
+  end # module Command
+end # module Swimmy


### PR DESCRIPTION
### **TL;DR**

- 株価の情報を表示するコマンドの実装

### **実装目的**

- 乃村研B4向けの新人研修課題に取り組むため
  - [新人研修課題](https://scrapbox.io/nompedia/swimmy_%E3%81%AE%E6%A9%9F%E8%83%BD%E8%BF%BD%E5%8A%A0)

### **使い方**
`/swimmy stock/`または`/swimmy stock XXXX/`と入力し，情報を表示する
![image](https://user-images.githubusercontent.com/81736651/114999085-7f42a580-9edc-11eb-859d-6bad4c3a3a0c.png)


### **実装内容**
- 日経平均株価または指定されたコードの株価を取得する機能
  - 株価のAPIはhttps://query1.finance.yahoo.com/v8/finance/chart/ を使用しました
  - 始値，高値，安値，終値と前日比を表示します