### PR TITLE
Add at command

### DIFF
--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -24,7 +24,7 @@ module Swimmy
           end
 
         else
-          client.say(channel: data.channel, text: help_message("say"))
+          client.say(channel: data.channel, text: help_message("at"))
         end
       end
 

--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -1,0 +1,63 @@
+require 'date'
+
+module Swimmy
+  module Command
+    class At < Swimmy::Command::Base
+      COMMAND_SCHEDULE = []
+
+      command "at" do |client, data, match|
+        arg = match[:expression].split(' ', 3)
+        if arg.size == 3 then
+
+          now = DateTime.now
+          date = DateTime.parse(DateTime.parse(arg[0]).strftime("%Y%m%dT%H:%M:%S") + DateTime.now.zone) rescue false
+
+          if ! date then
+            client.say(channel: data.channel, text: "時刻の指定がおかしいです")
+            break
+          elsif date <= now then
+            client.say(channel: data.channel, text: "未来の時間を指定してください")
+            break
+          else
+            COMMAND_SCHEDULE.append({date: date, text: arg[2], channel: data.channel, user: data.user})
+            client.say(channel: data.channel, text: "<##{data.channel}> で #{date} 頃， #{arg[2]} を実行します．")
+          end
+
+        else
+          client.say(channel: data.channel, text: help_message("say"))
+        end
+      end
+
+      help do
+        title "at"
+        desc "指定した日時にコマンドを実行します．"
+        long_desc "at <日時> do <文字列> - <日時> 頃，<文字列> をコマンドとして実行します．\n"
+      end
+
+      tick do |client, data|
+        puts "at command..."
+        now = DateTime.now
+
+        COMMAND_SCHEDULE.delete_if do |elem|
+          p (elem[:date])
+          p (elem[:channel]) 
+          p (elem[:text])
+          p (elem[:user])
+
+          if elem[:date] <= now
+            puts "at command sending message..."
+            text = 'swimmy ' + elem[:text]
+            SlackRubyBot::Hooks::Message.new.call(
+            client,
+            Hashie::Mash.new(type: 'message', text: text, channel: elem[:channel], user: elem[:user])
+            )
+            true
+          else
+            false
+          end
+        end
+      end
+
+    end # class Do
+  end # module Command
+end # module Swimmy

--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -38,14 +38,10 @@ module Swimmy
         puts "at command..."
         now = DateTime.now
 
-        COMMAND_SCHEDULE.delete_if do |elem|
-          p (elem[:date])
-          p (elem[:channel]) 
-          p (elem[:text])
-          p (elem[:user])
-
+        COMMAND_SCHEDULE.each do |elem|
           if elem[:date] <= now
             puts "at command sending message..."
+            client.say(channel: elem[:channel], text: "at コマンドによるコマンド実行です．")
             text = 'swimmy ' + elem[:text]
             SlackRubyBot::Hooks::Message.new.call(
             client,


### PR DESCRIPTION
#92 に対するPRである

## やったこと
指定した時刻にコマンドを実行する at コマンドを実装した．

at コマンドの仕様を以下に示す．
+ `swimmy at <日時> do <文字列>`
+ <日時> で指定した日時に，<文字列>をコマンドとして実行する．

<日時> は Datetime型で入力し，<文字列>には swimmy のコマンドを入力する．

## 使用例
```
swimmy at 12:00 do restart
```
上記の例だと，at コマンドを実行した日の12:00に restart コマンドを実行する．