### PR TITLE
Fix at command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem 'google-api-client', "~> 0.8"
 gem 'sheetq', :git => 'https://github.com/nomlab/sheetq.git'
 gem 'rspec'
 gem 'systemu'
+gem 'enumdate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     declarative-option (0.1.0)
     diff-lcs (1.3)
     dotenv (2.7.5)
+    enumdate (0.1.1)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
@@ -131,6 +132,7 @@ PLATFORMS
 DEPENDENCIES
   async-websocket (~> 0.8.0)
   dotenv
+  enumdate
   google-api-client (~> 0.8)
   rspec
   sheetq!

--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -56,13 +56,15 @@ module Swimmy
       tick do |client, data|
         puts "at command..."
 
+        now = Time.now
+
         if @@first_tick
           @@recurrences = SpreadSheetController.new(spreadsheet).read
           @@first_tick = false
         end
 
         for occurence in @@occurences
-          if occurence.should_execute?
+          if occurence.should_execute?(now)
             occurence.execute(client)
           end
         end
@@ -71,7 +73,7 @@ module Swimmy
 
         for recurrence in @@recurrences
           begin
-            occurence = Swimmy::Resource::Occurence.new(recurrence)
+            occurence = Swimmy::Resource::Occurence.new(recurrence, now)
             @@occurences.append(occurence)
           rescue RuntimeError
             # occurence is expired

--- a/spec/at_spec.rb
+++ b/spec/at_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe "At command test" do
+  before do
+    # create dummy data
+    @now = Time.parse("2021/4/1 00:00:00 JST")
+  end
+
+  it "create occurence from recurrence whose interval is once" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/4/2 00:00:00 JTS",
+        Swimmy::Resource::Interval::ONCE,
+        "true"
+      )
+    occurence = Swimmy::Resource::Occurence.new(recurrence, @now)
+    expect(occurence.exec_time).to eq(Time.parse("2021/4/2 00:00:00 JST"))
+  end
+
+  it "faile to create occurence from finished recurrence" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/3/31 00:00:00 JST",
+        Swimmy::Resource::Interval::ONCE,
+        "true"
+      )
+    expect{Swimmy::Resource::Occurence.new(recurrence, @now)}.to raise_error(RuntimeError)
+  end
+
+  it "create occurence from recurrence whose interval is everyday" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/3/1 23:00:00 JST",
+        Swimmy::Resource::Interval::DAY,
+        "true"
+      )
+    occurence = Swimmy::Resource::Occurence.new(recurrence, @now)
+    expect(occurence.exec_time).to eq(Time.parse("2021/4/1 23:00:00 JST"))
+  end
+
+  it "faile to create occurence from disabled recurrence" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/3/31 00:00:00 JST",
+        Swimmy::Resource::Interval::ONCE,
+        "false"
+      )
+    expect{Swimmy::Resource::Occurence.new(recurrence, @now)}.to raise_error(RuntimeError)
+  end
+
+  it "return true from should_execute?" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/4/2 00:00:00 JST",
+        Swimmy::Resource::Interval::ONCE,
+        "true"
+      )
+
+    occurence = Swimmy::Resource::Occurence.new(recurrence, @now)
+    expect(occurence.should_execute?(Time.parse("2021/4/3 00:00:00 JST"))).to be true
+  end
+
+  it "create occurence 7 times" do
+    recurrence =
+      Swimmy::Resource::Recurrence.new(
+        "test_command",
+        "test_user",
+        "test_channel",
+        "2021/4/1 12:00:00 JST",
+        Swimmy::Resource::Interval::DAY,
+        "true"
+      )
+
+    time = Time.parse("2021/4/1 00:00:00 JST")
+    occurence = Swimmy::Resource::Occurence.new(recurrence, time)
+    for i in 0..6 do
+      expect(occurence.should_execute?(time)).to eq false
+      date = time.to_date
+      time = Time.parse("#{date.next_day} #{time.strftime("%T %z")}")
+      expect(occurence.should_execute?(time)).to eq true
+      occurence = Swimmy::Resource::Occurence.new(recurrence, time)
+    end
+    p occurence.exec_time
+    expect(occurence.exec_time).to eq(Time.parse("2021/4/8 12:00 JST"))
+  end
+end


### PR DESCRIPTION
#92 ， #98 に対するPR

## 概要
1. at コマンドのバグの修正
2. at コマンドのテストの追加

## バグの修正
1. Date 型から Time 型 への変換の際にタイムゾーンの情報を含むように修正
2. exec_time の計算時に，eval を用いた計算から，enumdate を用いたものに変更

## テストの追加
1. calc_next_time の返り値を確認するテストを追加
