### PR TITLE
Allow to specify weekday option

### DIFF
--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -45,6 +45,7 @@ module Swimmy
           "[every <Interbal>] : この要素が指定された場合，コマンドを繰り返し実行します．\n" +
           "<Interval> : 繰り返しの間隔を以下の中から指定してください．\n" +
           "    ・day : 毎日\n" +
+          "    ・weekday : 毎日(平日のみ)\n" +
           "    ・week : 毎週\n" +
           "    ・month : 毎月\n" +
           "    ・year : 毎年\n" +


### PR DESCRIPTION
# やったこと
平日のみ毎日実行するオプションを追加した．

## 変更点
1. lib/swimmy/resource/schedule.rb
    * Interval クラスに WDAY 定数を追加
    * Interval が WDAY だった場合，Enumdate を用いて平日のみを対象とする Enumerator を作成するように追加
2. lib/swimmy/command/at.rb
    * help に weekdayオプションに関する情報を追記 