### PR TITLE
Add search_restaurant command

### DIFF
--- a/lib/swimmy/command/search_restaurant.rb
+++ b/lib/swimmy/command/search_restaurant.rb
@@ -1,16 +1,15 @@
 # coding: utf-8
-require "net/http"
-require "json"
-require "rexml/document"
 
 module Swimmy
   module Command
     class Search_restaurant < Swimmy::Command::Base
+      HOTPEPPER_CREDIT = "Powered by <http://webservice.recruit.co.jp/|ホットペッパー Webサービス>"
 
       command "search_restaurant" do |client,data,match|
         rio = Swimmy::Service::RestaurantInfo.new
         restaurant = rio.random_fetch_info(match[:expression])
-        client.say(channel: data.channel,text: restaurant.to_s)
+        chat_text = restaurant.to_s + HOTPEPPER_CREDIT
+        client.say(channel: data.channel,text: chat_text)
       end #do |client,data,match|
 
       help do

--- a/lib/swimmy/command/search_restaurant.rb
+++ b/lib/swimmy/command/search_restaurant.rb
@@ -1,0 +1,25 @@
+# coding: utf-8
+require "net/http"
+require "json"
+require "rexml/document"
+
+module Swimmy
+  module Command
+    class Search_restaurant < Swimmy::Command::Base
+
+      command "search_restaurant" do |client,data,match|
+        rio = Swimmy::Service::RestaurantInfo.new
+        restaurant = rio.random_fetch_info(match[:expression])
+        client.say(channel: data.channel,text: restaurant.to_s)
+      end #do |client,data,match|
+
+      help do
+        title "search_restaurant"
+        desc "検索ワードに基づいて飲食店を検索します"
+        long_desc "検索するワードを<keyword>として以下のように入力することで，検索ワードに基づいた飲食店を検索します．\n" +
+                  "search_restaurant <keyword>"
+      end
+
+    end #Class Search_restaurant
+  end #module Command
+end #module Swimmy

--- a/lib/swimmy/command/search_restaurant.rb
+++ b/lib/swimmy/command/search_restaurant.rb
@@ -3,12 +3,11 @@
 module Swimmy
   module Command
     class Search_restaurant < Swimmy::Command::Base
-      HOTPEPPER_CREDIT = "Powered by <http://webservice.recruit.co.jp/|ホットペッパー Webサービス>"
 
       command "search_restaurant" do |client,data,match|
         rio = Swimmy::Service::RestaurantInfo.new
         restaurant = rio.random_fetch_info(match[:expression])
-        chat_text = restaurant.to_s + HOTPEPPER_CREDIT
+        chat_text = restaurant.to_s + rio.credit
         client.say(channel: data.channel,text: chat_text)
       end #do |client,data,match|
 

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -12,5 +12,6 @@ module Swimmy
     autoload :Recurrence,  "#{dir}/schedule.rb"
     autoload :Occurence,   "#{dir}/schedule.rb"
     autoload :CoronaInfo,  "#{dir}/coronaresource.rb"
+    autoload :Restaurant,  "#{dir}/restaurant.rb"
   end
 end

--- a/lib/swimmy/resource/restaurant.rb
+++ b/lib/swimmy/resource/restaurant.rb
@@ -1,26 +1,29 @@
 # coding: utf-8
+
 module Swimmy
   module Resource
     class Restaurant
 
-      def initialize(rexml_restaurant)
-        parse(rexml_restaurant)
+      def initialize(name, address, open, url)
+        @name = name
+        @address = address
+        @open = open
+        @url = url
       end
 
-      def parse(rexml_restaurant)
-        @name = rexml_restaurant.elements["name"].text
-        @address =  rexml_restaurant.elements["address"].text
-        @open = rexml_restaurant.elements["open"].text
-        @url = rexml_restaurant.elements["urls/pc"].text
-        @credit = "Powered by <http://webservice.recruit.co.jp/|ホットペッパー Webサービス>"
+      def self.parse_rexml(rexml_restaurant)
+        name = rexml_restaurant.elements["name"].text
+        address =  rexml_restaurant.elements["address"].text
+        open = rexml_restaurant.elements["open"].text
+        url = rexml_restaurant.elements["urls/pc"].text
+        Restaurant.new(name, address, open, url)
       end
 
-      def to_s #表示形式の文字列に整形
+      def to_s
          "Name : #{@name}\n" +
          "Address : #{@address}\n" +
          "Open : #{@open}\n" +
-         "URL : #{@url}\n" +
-         "#{@credit}"
+         "URL : #{@url}\n"
       end
 
     end

--- a/lib/swimmy/resource/restaurant.rb
+++ b/lib/swimmy/resource/restaurant.rb
@@ -1,0 +1,28 @@
+# coding: utf-8
+module Swimmy
+  module Resource
+    class Restaurant
+
+      def initialize(rexml_restaurant)
+        parse(rexml_restaurant)
+      end
+
+      def parse(rexml_restaurant)
+        @name = rexml_restaurant.elements["name"].text
+        @address =  rexml_restaurant.elements["address"].text
+        @open = rexml_restaurant.elements["open"].text
+        @url = rexml_restaurant.elements["urls/pc"].text
+        @credit = "Powered by <http://webservice.recruit.co.jp/|ホットペッパー Webサービス>"
+      end
+
+      def to_s #表示形式の文字列に整形
+         "Name : #{@name}\n" +
+         "Address : #{@address}\n" +
+         "Open : #{@open}\n" +
+         "URL : #{@url}\n" +
+         "#{@credit}"
+      end
+
+    end
+  end
+end

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -7,5 +7,6 @@ module Swimmy
     autoload :Weather,     "#{dir}/weather.rb"
     autoload :Anniversary, "#{dir}/anniversary.rb"
     autoload :Coronainfo,  "#{dir}/coronainfo.rb"
+    autoload :RestaurantInfo, "#{dir}/restaurant_info.rb"
   end
 end

--- a/lib/swimmy/service/restaurant_info.rb
+++ b/lib/swimmy/service/restaurant_info.rb
@@ -1,36 +1,37 @@
 # coding: utf-8
+require "rexml/document"
+require "net/http"
+require "timeout"
+
 module Swimmy
   module Service
     class RestaurantInfo
 
-      def initialize()
-      end
+      def fetch_info(keyword)
+        keyword ||="日本"
 
-      def fetch_info(search_word)
-        if search_word == nil then
-          keyword = "日本"
-        else
-          keyword = search_word
-        end
-        
         encoded_URI = URI.encode "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=5a9f7a611fa1993e&keyword=#{keyword.encode("UTF-8")}"
 
         url = URI.parse(encoded_URI)
-        https = Net::HTTP.new(url.host, url.port)  
+        https = Net::HTTP.new(url.host, url.port)
         https.use_ssl = true
         req = Net::HTTP::Get.new(url.path + "?" + url.query)
         res = https.request(req)
         doc = REXML::Document.new(res.body)
+
+        restaurants = []
+        doc.get_elements("//results/shop").each do |shop|
+          restaurants << Swimmy::Resource::Restaurant.parse_rexml(shop)
+        end
+        restaurants
       end
 
-      def random_fetch_info(search_word)
-        doc = fetch_info(search_word)
-        # 1~(SHOPの上限数)の間で無作為に数を選ぶ
-        upper_limit = doc.get_elements("//results/shop").size
-        random_num = rand(1..upper_limit)
-        random_restaurant = doc.elements["results/shop[#{random_num}]"]
-        Swimmy::Resource::Restaurant.new(random_restaurant)
+      def random_fetch_info(keyword)
+        restaurants = fetch_info(keyword)
+        restaurants.sample
       end
+
+      private :fetch_info
 
     end
   end

--- a/lib/swimmy/service/restaurant_info.rb
+++ b/lib/swimmy/service/restaurant_info.rb
@@ -8,7 +8,7 @@ module Swimmy
     class RestaurantInfo
 
       def fetch_info(keyword)
-        keyword ||="日本"
+        keyword ||="居酒屋"
 
         encoded_URI = URI.encode "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=5a9f7a611fa1993e&keyword=#{keyword.encode("UTF-8")}"
 

--- a/lib/swimmy/service/restaurant_info.rb
+++ b/lib/swimmy/service/restaurant_info.rb
@@ -1,0 +1,37 @@
+# coding: utf-8
+module Swimmy
+  module Service
+    class RestaurantInfo
+
+      def initialize()
+      end
+
+      def fetch_info(search_word)
+        if search_word == nil then
+          keyword = "日本"
+        else
+          keyword = search_word
+        end
+        
+        encoded_URI = URI.encode "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=5a9f7a611fa1993e&keyword=#{keyword.encode("UTF-8")}"
+
+        url = URI.parse(encoded_URI)
+        https = Net::HTTP.new(url.host, url.port)  
+        https.use_ssl = true
+        req = Net::HTTP::Get.new(url.path + "?" + url.query)
+        res = https.request(req)
+        doc = REXML::Document.new(res.body)
+      end
+
+      def random_fetch_info(search_word)
+        doc = fetch_info(search_word)
+        # 1~(SHOPの上限数)の間で無作為に数を選ぶ
+        upper_limit = doc.get_elements("//results/shop").size
+        random_num = rand(1..upper_limit)
+        random_restaurant = doc.elements["results/shop[#{random_num}]"]
+        Swimmy::Resource::Restaurant.new(random_restaurant)
+      end
+
+    end
+  end
+end

--- a/lib/swimmy/service/restaurant_info.rb
+++ b/lib/swimmy/service/restaurant_info.rb
@@ -26,6 +26,11 @@ module Swimmy
         restaurants
       end
 
+      def credit()
+        credit = "Powered by <http://webservice.recruit.co.jp/|ホットペッパー Webサービス>"
+        return credit
+      end
+
       def random_fetch_info(keyword)
         restaurants = fetch_info(keyword)
         restaurants.sample


### PR DESCRIPTION
# 概要
search_restaurantコマンドの追加
# 変更点
- lib/swimmy/command以下にsearch_restaurant.rbを追加した
- lib/swimmy/resource以下にrestaurant.rbを追加した
- lib/swimmy/service以下にrestaurant_info.rbを追加した

# コマンドの概要
## 機能
入力された検索ワードからホットペッパーのサービスを利用して飲食店の検索を行う．
検索によって得られた検索結果の中から1店舗を選出し，以下の情報を出力する
- 店舗名
- 住所
- 営業時間
-  ホットペッパーのURL

## 使用方法
Slack上で`/swimmy search_restaurant XXXX/`と入力する
(`XXXX`には検索したいワードが入る)


### 特徴
ホットペッパーのWebAPIを使用している
[ホットペッパー | APIリファレンス | リクルートWEBサービス](https://webservice.recruit.co.jp/doc/hotpepper/reference.html)