### PR TITLE
Update say command to use  with at command

### DIFF
--- a/lib/swimmy/command/say.rb
+++ b/lib/swimmy/command/say.rb
@@ -1,58 +1,21 @@
-require 'date'
-
-
 module Swimmy
   module Command
     class Say < Swimmy::Command::Base
-      POST_SCHEDULE = []
 
       command "say" do |client, data, match|
-        arg = match[:expression].split(' ', 2)
-        if arg.size == 2 then
-
-          now = DateTime.now
-          date = DateTime.parse(DateTime.parse(arg[0]).strftime("%Y%m%dT%H:%M:%S") + DateTime.now.zone) rescue false
-
-          if ! date then
-            client.say(channel: data.channel, text: "時刻の指定がおかしいです")
-            break
-          elsif date <= now then
-            client.say(channel: data.channel, text: "未来の時間を指定してください")
-            break
-          else
-            POST_SCHEDULE.append({date: date, text: arg[1], channel: data.channel})
-            client.say(channel: data.channel, text: "<##{data.channel}> に #{date}に通知します．")
-          end
-
-        else
+    
+        if match[:expression] == nil
           client.say(channel: data.channel, text: help_message("say"))
         end
-      end
-
+ 
+        client.say(channel:  data.channel, text: "#{match[:expression]}")      
+          
       help do
         title "say"
-        desc "指定の時間に指定された文字列を発言します．"
-        long_desc "say <時間> <文字列> - <時間> 頃，このチャンネルに<文字列>と発言します．\n"
+        desc "文字列を発言します．"
+        long_desc "say <文字列> - このチャンネルに<文字列>と発言します．\n"
       end
-
-      tick do |client, data|
-        puts "say command..."
-        now = DateTime.now
-
-        POST_SCHEDULE.delete_if do |elem|
-          p (elem[:date])
-          p (elem[:channel]) 
-          p (elem[:text])
-          if elem[:date] <= now
-            puts "Say command Sending message..."
-
-            client.say(channel: elem[:channel], text: elem[:text])
-            true
-          else
-            false
-          end
-        end
-      end
+     end
 
     end # class Say
   end # module Command


### PR DESCRIPTION
## 概要
say コマンドでの時間指定の機能を削除し，即座に文字列を表示するように変更した．
## 変更理由
atコマンドは指定した時間にコマンドを実行するコマンドであるため， at コマンドにて say コマンドを使用する際に．2回時間指定を行う必要があるため．
## 変更点
lib/swimmy/command 以下のsay.rbの時間指定の機能部分を削除した．
## 変更後の仕様
`swimmy say <文字列>` で指定された文字列を直後に発言する．