### PR TITLE
Change to use display_name where real_name was used.

### DIFF
--- a/lib/swimmy/command/at.rb
+++ b/lib/swimmy/command/at.rb
@@ -8,7 +8,7 @@ module Swimmy
       command "at" do |client, data, match|
 
         channel = data.channel
-        user_name = client.web_client.users_info(user: data.user).user.real_name
+        user_name = client.web_client.users_info(user: data.user).user.profile.display_name
         args = match[:expression]
         ss_controller = SpreadSheetController.new(spreadsheet)
 

--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -9,7 +9,7 @@ module Swimmy
 
         cmd = match[:command]
         now = Time.now
-        usr = client.web_client.users_info(user: data.user).user.real_name
+        usr = client.web_client.users_info(user: data.user).user.profile.display_name
 
         client.say(channel: data.channel, text: "記録中: #{now.strftime('%Y-%m-%d %H:%M:%S')} #{cmd} #{usr}...")
 

--- a/lib/swimmy/command/memo.rb
+++ b/lib/swimmy/command/memo.rb
@@ -8,7 +8,7 @@ module Swimmy
       command "memo" do |client, data, match|
 
         now = Time.now
-        usr = client.web_client.users_info(user: data.user).user.real_name
+        usr = client.web_client.users_info(user: data.user).user.profile.display_name
         if match[:expression]
           client.say(channel: data.channel, text: "メモを記録中: #{now.strftime('%Y-%m-%d %H:%M:%S')} #{usr}...")
           begin


### PR DESCRIPTION
以下のプログラムに関して，Slackにおける氏名(real_name)を使用していた部分を表示名(display_name)を使用するように変更した．
1. lib/swimmy/command/at.rb
2. lib/swimmy/command/attendance.rb
3. lib/swimmy/command/memo.rb