### PR TITLE
Add list option to nomnichi command

### DIFF
--- a/lib/swimmy/command/nomnichi.rb
+++ b/lib/swimmy/command/nomnichi.rb
@@ -7,19 +7,26 @@ module Swimmy
         client.say(channel: data.channel, text: "履歴取得中...")
 
         begin
-          who = WorkHorse.new(spreadsheet).whosnext
+          targets = WorkHorse.new(spreadsheet).nomnichi_targets
         rescue Exception => e
           client.say(channel: data.channel, text: "履歴を取得できませんでした.")
           raise e
         end
 
-        client.say(channel: data.channel, text: "次回のノムニチ担当は，#{who} さんです!")
+        case match[:expression]
+        when nil
+          client.say(channel: data.channel, text: "次回のノムニチ担当は，#{targets.first} さんです!")
+        when 'list'
+          client.say(channel: data.channel, text: "次回以降のノムニチ担当は，以下の通りです!\n#{targets.join("\n")}")
+        else
+          client.say(channel: data.channel, text: help_message("nomnichi"))
+        end
       end
 
       help do
         title "nomnichi"
         desc "次のノムニチ執筆者を教えてくれます"
-        long_desc "次のノムニチ執筆者を教えてくれます．引数はありません．"
+        long_desc "nomnichi list - 次回以降のノムニチ執筆者を教えてくれます．"
       end
 
       ################################################################
@@ -33,8 +40,8 @@ module Swimmy
           @spreadsheet = spreadsheet
         end
 
-        def whosnext
-          whos_next(nomnichi_active_members, fetch_nomnichi_articles)
+        def nomnichi_targets
+          capture_targets(nomnichi_active_members, fetch_nomnichi_articles)
         end
 
         private
@@ -47,7 +54,7 @@ module Swimmy
           Sheetq::Service::Nomnichi.new.fetch
         end
 
-        def whos_next(current_member_account_names, articles)
+        def capture_targets(current_member_account_names, articles)
           epoch = Time.new(1970, 1, 1)
           old_to_new_articles =  articles.sort {|a, b| a.published_on <=> b.published_on}
           latest_published_time = Hash.new
@@ -61,7 +68,7 @@ module Swimmy
             latest_published_time[article.user_name] = article.published_on
           end
 
-          return latest_published_time.sort{|a, b| a[1] <=> b[1]}.first[0]
+          return latest_published_time.sort{|a, b| a[1] <=> b[1]}.map(&:first)
         end
       end
       private_constant :WorkHorse


### PR DESCRIPTION
## 概要
swimmy の nomnichi コマンドに list オプションを追加した．

nomnichi コマンドは次のノムニチ執筆者を教えてくれる機能を持っている．
これに加えて，全員の執筆順番を知りたいという声が研究室内で上がったため，実装に至った．

## 変更点
- capture_targets (旧 whos_next) メソッドの戻り値を次回の執筆者名 (String) から次回以降の執筆者リスト (Array) に変更した．
- capture_targets (旧 whos_next) メソッドの戻り値の変更に伴い，メソッド名および変数名を以下のように変更した．
  - whos_next -> capture_targets (メソッド)
  - whosnext -> nomnichi_targets (メソッド)
  - who -> targets (ローカル変数)
- help メッセージの変更した．
- コマンド引数に応じて，クライアントに返すメッセージを変更した．

## 使用方法
![スクリーンショット 2022-11-18 151447](https://user-images.githubusercontent.com/58807709/202633877-473ccce3-cbdf-40ad-83b9-20211804f4f2.png)
![スクリーンショット 2022-11-18 151246](https://user-images.githubusercontent.com/58807709/202633743-b521cedf-e754-430f-b349-8b18d5e2aaca.png)

