### PR TITLE
Change require order for dotenv

### DIFF
--- a/exe/swimmy
+++ b/exe/swimmy
@@ -25,12 +25,11 @@ end
 Encoding.default_external = "UTF-8"
 Thread.abort_on_exception = true
 
+require "dotenv"
+Dotenv.load
 require "rubygems"
 require "swimmy"
-require "dotenv"
 require "optparse"
-
-Dotenv.load
 
 ################################################################
 ### Main thread


### PR DESCRIPTION
### 問題
swimmy の起動時に command の help において envファイルの情報を読み込むことができず，エラーで止まる．
### 原因
`require "swimmy"`の時に各コマンドの help が実行されるが，`require "swimmy"`よりも後に exe/swimmy の`Dotenv.load`が実行される．そのため，help 内で envファイルの情報を使用する場合エラーで止まる．
### 変更点
exe/swimmy において`Dotenv.load`が`require swimmy`より先に実行されるように変更した．