### PR TITLE
Add openhab command

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,3 +12,6 @@ GOOGLE_PLACES_API_KEY=ThisIsSampleAPIKeyIoCgJ1BgvDLB5hqCi99NB
 
 # Use in rain_information.rb
 YAHOO_API_KEY=ThisIsSampleAPIKeycfNzF5ysXqx3trYn5XFxPBsQOsBmz9Owi8bGYs
+
+# Use in openhab.rb
+OPENHAB_URL=http://openhab.example.com

--- a/lib/swimmy/command/openhab.rb
+++ b/lib/swimmy/command/openhab.rb
@@ -1,0 +1,55 @@
+module Swimmy
+  module Command
+    class Openhab < Swimmy::Command::Base
+      command "openhab" do |client, data, match|
+        OPENHAB_URL = ENV["OPENHAB_URL"]
+        if OPENHAB_URL == nil
+          client.say(channel: data.channel, text: ".env に必要な項目がありません．")
+          return
+        end
+        keyword = match[:expression]
+        result_text = ""
+        error_text = "データが存在しません．入力が間違っている可能性があります．\n" +
+                     "\"swimmy help openhab\" と入力して使用可能なキーワードを確認してください．"
+        result_data = Swimmy::Service::Openhab.new(OPENHAB_URL, "swimmy").fetch_info
+        result_data.each do |data|
+          if data.value == keyword
+            result_text += data.state
+            result_text += "\n"
+          end
+        end
+        if result_text == ""
+          client.say(channel: data.channel, text: error_text)
+        else 
+          client.say(channel: data.channel, text: result_text)
+        end
+      end 
+
+      help do
+        OPENHAB_URL = ENV["OPENHAB_URL"]
+        help = ""
+        if OPENHAB_URL == nil
+          help = ".env に必要な項目がありません．追加して再起動してください．"
+        else
+          helpinfo = Swimmy::Service::Openhab.new(OPENHAB_URL, "swimmy").fetch_info
+          helpinfo.each do |openhab_data|
+            help += openhab_data.value
+            help += "："
+            help += openhab_data.config["description"]
+            help += "\n"
+          end
+        end
+
+        title "openhab"
+        desc "キーワードに対応したOpenHAB上の情報を表示します"
+        long_desc "表示したい情報を<keyword>として以下のように入力することで，
+                   対応した情報を表示します．\n" +
+                  "openhab <keyword>\n" +
+                  "使用可能なキーワードは以下のものです．\n" +
+                  "<keyword> : <description> \n" +
+                  help 
+      end
+
+    end
+  end
+end

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -16,5 +16,6 @@ module Swimmy
     autoload :GoogleOAuth, "#{dir}/google_oauth.rb"
     autoload :Event,       "#{dir}/event.rb"
     autoload :Pollen,      "#{dir}/pollen_resource.rb"
+    autoload :OpenhabMetadata, "#{dir}/openhab_metadata.rb"
   end
 end

--- a/lib/swimmy/resource/openhab_metadata.rb
+++ b/lib/swimmy/resource/openhab_metadata.rb
@@ -1,0 +1,14 @@
+module Swimmy
+  module Resource
+    class OpenhabMetadata
+      attr_reader :name, :value, :state, :config
+      
+      def initialize(metadataname, value, state, config)
+        @name = metadataname
+        @value = value 
+        @state = state
+        @config = config
+      end
+    end
+  end
+end

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -13,5 +13,6 @@ module Swimmy
     autoload :Doorplate,   "#{dir}/doorplate.rb"
     autoload :Pollen,      "#{dir}/pollen_service.rb"
     autoload :CityCode,    "#{dir}/city_code.rb"
+    autoload :Openhab, "#{dir}/openhab.rb"
   end
 end

--- a/lib/swimmy/service/openhab.rb
+++ b/lib/swimmy/service/openhab.rb
@@ -1,0 +1,28 @@
+module Swimmy
+  module Service
+    class Openhab
+      require "json"
+      require "uri"
+      require "open-uri"
+
+      def initialize(openhab_url, metadataname)
+        @openhab_url = openhab_url + "/rest/items?metadata=" + metadataname
+        @metadataname = metadataname 
+      end
+
+      def fetch_info
+        retval = []
+        opinfo = JSON.parse(URI.open(@openhab_url, &:read)) 
+        opinfo.each do |openhab_data|
+          next if openhab_data["metadata"] == nil
+          retval.push(Swimmy::Resource::OpenhabMetadata.new(@metadataname, 
+                                                            openhab_data["metadata"][@metadataname]["value"],
+                                                            openhab_data["state"],
+                                                            openhab_data["metadata"][@metadataname]["config"]))
+        end
+        return retval
+      end
+
+    end # class Openhabinfo
+  end # module Service
+end # module Swimmy


### PR DESCRIPTION
# 概要
openhab コマンドの追加

# コマンドの概要

## 機能
指定されたキーワードに応じた，openHAB 上で管理されている情報を表示する．

## 使用方法
`swimmy openhab <キーワード>` と入力する．
`swimmy help openhab` と入力して helpコマンドを使用することで使用可能なキーワードの一覧を表示する．

## 特徴
[openHAB の REST API](https://www.openhab.org/docs/configuration/restdocs.html) を使用している．
