### PR TITLE
Add upcoming command

### DIFF
--- a/lib/swimmy/command/upcoming.rb
+++ b/lib/swimmy/command/upcoming.rb
@@ -1,0 +1,65 @@
+# coding: utf-8
+# This is a part of https://github.com/nomlab/swimmy
+require 'pp'
+require 'date'
+require 'fileutils'
+require 'active_support/time'
+require 'sheetq'
+module Swimmy
+  module Command
+    class Upcoming < Swimmy::Command::Base
+      command "upcoming" do |client, data, match|
+        if match[:expression].match(" ") then
+          message = "引数の数が正しくありません．検索するキーワードを<keyword>として以下のように入力してください．\n" +
+          "upcoming\n" +
+          "または\n" +
+          "upcoming <keyword>\n"
+        else
+          client.say(channel: data.channel, text: "予定を取得中...")
+          message = ""
+          @sheet = spreadsheet.sheet("calendar", Swimmy::Resource::Calendar)
+          begin
+            service =  Swimmy::Service::CalendarService.new
+          rescue => e
+            message = 'Google OAuthの認証に失敗しました．適切な認証情報が設定されているか確認してください．'
+          end
+          
+          begin
+            # spreadsheetからカレンダー名とカレンダーidを取得する
+            calendars = @sheet.fetch
+            #calendarsは(カレンダー名，カレンダーid)の組
+            events = service.get_events(calendars,match[:expression])
+  
+            if match[:expression].nil? then
+              message = "1ヶ月の予定\n"
+              message = "- 1ヶ月の予定はありません．\n" if events.empty?
+            else
+              message = "(#{match[:expression]})に関する予定\n"
+              message = "- #{match[:expression]}に関する予定はありません．\n" if events.empty?
+            end
+            events.each do |event|
+              message << "#{event.start.strftime('%m月%d日')} (#{event.day_of_week}) #{event.start.strftime('%H:%M:%S')} #{event.summary} (#{event.calendar_name})\n"
+            end
+  
+          rescue => e
+            message << "予定の取得に失敗しました．"
+          end
+        end
+        client.say(channel: data.channel, text: message)
+
+      end # command upcoming
+
+      help do
+        title "upcoming"
+        desc "1ヶ月先までの全ての予定，またはキーワードに関する予定を表示します．"
+        long_desc "引数がない場合は1ヶ月先までの予定を全て表示します．\n" +
+                  "引数がある場合は1ヶ月先までの予定のうち，日時，予定名，作成者のいずれかに引数を含む予定を表示します．\n" +
+                  "検索するキーワードを<keyword>として以下のように入力してください．\n" +
+                  "upcoming\n" +
+                  "または\n" + 
+                  "upcoming <keyword>\n"
+      end # help message
+
+    end # Upcoming class
+  end
+end

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -14,5 +14,6 @@ module Swimmy
     autoload :CoronaInfo,  "#{dir}/coronaresource.rb"
     autoload :Restaurant,  "#{dir}/restaurant.rb"
     autoload :GoogleOAuth, "#{dir}/google_oauth.rb"
+    autoload :Event,       "#{dir}/event.rb"
   end
 end

--- a/lib/swimmy/resource/event.rb
+++ b/lib/swimmy/resource/event.rb
@@ -1,0 +1,23 @@
+# coding: utf-8
+require 'pp'
+require 'date'
+require 'fileutils'
+require 'active_support/time'
+module Swimmy
+    module Resource
+      class Event
+        attr_reader :start,:summary,:calendar_name
+        def initialize(start, summary, calendar_name)
+          @start = DateTime.parse(start)
+          @summary = summary
+          @calendar_name = calendar_name
+        end
+
+        def day_of_week
+          days_of_week = ["None","月","火","水","木","金","土","日"]
+          day_of_week = @start.strftime('%u')
+          day_of_week = days_of_week[day_of_week.to_i];
+      end
+    end
+  end
+end

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -8,5 +8,6 @@ module Swimmy
     autoload :Anniversary, "#{dir}/anniversary.rb"
     autoload :Coronainfo,  "#{dir}/coronainfo.rb"
     autoload :RestaurantInfo, "#{dir}/restaurant_info.rb"
+    autoload :CalendarService,    "#{dir}/calendar_service.rb"
   end
 end

--- a/lib/swimmy/service/calendar_service.rb
+++ b/lib/swimmy/service/calendar_service.rb
@@ -1,0 +1,88 @@
+# coding: utf-8
+require 'json'
+require 'uri'
+require 'net/https'
+require 'pp'
+require 'date'
+require 'fileutils'
+require 'active_support/time'
+
+module Swimmy
+  module Service
+    class CalendarService
+
+      def initialize
+        @google_oauth ||= begin
+            Swimmy::Resource::GoogleOAuth.new('config/credentials.json', 'config/tokens.json')
+        rescue e
+          return
+        end
+      end
+
+      def get_events(calendars,keyword)
+        events = []
+        calendars.each do |calendar|
+          events.concat(get_event(calendar.id, calendar.name))
+        end
+
+        if !keyword.nil? then
+          events = search_keyword_events(events,keyword)
+        end
+        events = events.sort_by{|x| x.start}
+        return events
+      end
+
+      private
+
+      def get_event(calendar_id, calendar_name)
+        events = []
+        raw_events = fetch_info(calendar_id, @google_oauth.token)
+        events = format_events_from_json(raw_events, calendar_name)
+        return events
+      end
+
+      def fetch_info(calendar_id, access_token)
+        uri = URI.parse("https://www.googleapis.com/calendar/v3/calendars/#{calendar_id}/events")
+        now = DateTime.now
+        future = now >> 1
+        query = { singleEvents: 'true',
+                  timeMin: now.rfc3339,
+                 timeMax: future.rfc3339}
+        uri.query = URI.encode_www_form(query)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        req = Net::HTTP::Get.new(uri.request_uri)
+        req['Accept'] = 'application/json'
+        req['Authorization'] = "Bearer #{access_token}"
+        res = http.request(req)
+        res.body
+      end
+
+      def format_events_from_json(json_str, calendar_name)
+        formated_events = []
+        json = JSON.parse(json_str)
+        json['items'].each do |event|
+          start = event['start']['dateTime'] || event['start']['date']
+          summary = event['summary']
+          formated_events.push(Swimmy::Resource::Event.new(start, summary, calendar_name))
+        end
+  
+        formated_events
+      end
+
+      def search_keyword_events(events,keyword)
+        keyword_events = []
+        events.each do |event|
+          if event.start.strftime('%m月%d日').match?(keyword) || event.summary.match?(keyword) || event.calendar_name.match?(keyword) then
+            keyword_events.push(event)
+          else
+            next
+          end
+        end
+        keyword_events
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
# 概要
upcomingコマンドの実装
## 変更点

- lib/swimmy/command 以下に upcoming.rb を追加
- lib/swimmy/service 以下に calendar_service.rb を追加
- lib/swimmy/resource 以下に event.rb を追加

コードレビューに基づいてコードの内容を変更しました．

# コマンドの概要

## 機能
1ヶ月先までの全ての予定を表示，またはこのうちキーワードで知りたい予定を絞り込み表示する．
## 使用方法
- Slackのnomlabワークスペースで `swimmy upcoming` と入力して1ヶ月先までの予定を表示する．
- Slackのnomlabワークスペースで `swimmy upcoming <keyword>` と入力して1ヵ月先までの予定のうち<keyword\>を含む予定のみ表示する．
## 特徴
- Google Calendar APIを使用している．