### PR TITLE
Add pollen information command

### DIFF
--- a/lib/swimmy/command/pollen.rb
+++ b/lib/swimmy/command/pollen.rb
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+require 'date'
+
+module Swimmy
+  module Command
+    class Pollen < Swimmy::Command::Base
+
+      command "pollen" do |client, data, match|
+        today  = Time.now
+        address = if match[:expression] then match[:expression] else  '岡山市北区' end
+
+        client.say(channel: data.channel, text: "花粉情報を取得しています……")
+
+        begin
+          info = Service::Pollen.new.fetch_info(address, today)
+          message = <<~EOS
+          #{info.date.strftime("%F")} #{(info.date.strftime("%H").to_i - 1).to_s}-#{info.date.strftime("%H")}時における#{info.address}の花粉飛散数は，
+          #{info.pollen}
+          EOS
+        rescue Service::Pollen::CityCodeException
+          message = <<~EOS
+          通信に失敗したか，市区町村名が正しく入力されていません．
+          市区町村名は "swimmy pollen 岡山市北区" のように入力してください．
+          EOS
+        rescue Service::Pollen::PollenException
+          message = <<~EOS
+          花粉飛散数データベースが更新されていません．
+          対応する市区町村が入力されていますか？
+          正しく入力されている場合にこのメッセージが表示された場合は
+          WebAPIが失効している可能性があります．
+          EOS
+        end
+        client.say(channel: data.channel, text: message)
+      end
+
+      help do
+        title "pollen"
+        desc "指定した市区町村の1時間前の花粉飛散数[個/m^2]を表示します．"
+        long_desc "pollen \n" +
+                  "岡山市北区の1時間前の花粉飛散数[個/m^2]を表示します．\n" +
+                  "pollen <市区町村名>\n" +
+                  "引数に指定した市区町村の1時間前の花粉飛散数[個/m^2]を表示します．\n"
+      end
+    end # class Pollen
+  end # module Command
+end # module Swimmy

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -15,5 +15,6 @@ module Swimmy
     autoload :Restaurant,  "#{dir}/restaurant.rb"
     autoload :GoogleOAuth, "#{dir}/google_oauth.rb"
     autoload :Event,       "#{dir}/event.rb"
+    autoload :Pollen,      "#{dir}/pollen_resource.rb"
   end
 end

--- a/lib/swimmy/resource/pollen_resource.rb
+++ b/lib/swimmy/resource/pollen_resource.rb
@@ -1,0 +1,25 @@
+# coding: utf-8
+module Swimmy
+  module Resource
+    class Pollen
+      attr_reader :address, :date, :pollen
+
+      def initialize(address, date, pollen)
+        @address, @date = address, date
+        if pollen == '-9999'
+          @pollen = '観測できませんでした．'
+        else
+          @pollen = <<~EOS
+            #{pollen.to_s} [個/m^2]です．
+          EOS
+        end
+      end
+
+      def to_s
+        "Prefecture: #{city_code}\n" +
+          "Date: #{date}\n" +
+          "Pollen: #{pollen}\n"
+      end
+    end # class Pollen
+  end # module Resource
+end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -11,5 +11,7 @@ module Swimmy
     autoload :CalendarService,    "#{dir}/calendar_service.rb"
     autoload :AttendanceLogger,  "#{dir}/attendance_logger.rb"
     autoload :Doorplate,   "#{dir}/doorplate.rb"
+    autoload :Pollen,      "#{dir}/pollen_service.rb"
+    autoload :CityCode,    "#{dir}/city_code.rb"
   end
 end

--- a/lib/swimmy/service/city_code.rb
+++ b/lib/swimmy/service/city_code.rb
@@ -1,0 +1,51 @@
+# coding: utf-8
+
+require 'net/http'
+require 'uri'
+
+module Swimmy
+  module Service
+    class CityCode
+
+      class HttpException < StandardError; end
+      class NonExistentException < StandardError; end
+
+      def address_to_city_code(address)
+        pre = Thread.new {address_to_prefecture_code(address)}
+        add = Thread.new {address_to_address_code(address)}
+        return pre.value + add.value  # 例外を素通りさせる
+      end
+
+      private
+
+      def address_to_prefecture_code(address)
+        encoded_city = URI.encode_www_form_component(address)
+        url = URI.parse("https://api.excelapi.org/post/prefcode?")
+        url.query = "address=#{encoded_city}}"
+        begin
+          res = Net::HTTP.get(url)
+          raise NonExistentException.new if res.include?("ERROR")
+          return res
+        rescue => e
+          raise NonExistentException.new if e.is_a?(NonExistentException)
+          raise HttpException.new
+        end
+      end
+
+      def address_to_address_code(address)
+        encoded_city = URI.encode_www_form_component(address)
+        url = URI.parse("https://api.excelapi.org/post/areacode?")
+        url.query = "address=#{encoded_city}}"
+        begin
+          res = Net::HTTP.get(url)
+          raise NonExistentException.new if res.include?("ERROR")
+          return res
+        rescue => e
+          raise NonExistentException.new if e.is_a?(NonExistentException)
+          raise HttpException.new
+        end
+      end
+
+    end # class CityCode
+  end # module Service
+end # module Swimmy

--- a/lib/swimmy/service/pollen_service.rb
+++ b/lib/swimmy/service/pollen_service.rb
@@ -1,0 +1,40 @@
+# coding: utf-8
+
+require 'date'
+require 'csv'
+require 'net/http'
+
+module Swimmy
+  module Service
+    class Pollen
+
+      class CityCodeException < StandardError; end
+      class PollenException < StandardError; end
+
+      def fetch_info(address, date)
+        begin
+          city_code = Service::CityCode.new.address_to_city_code(address)
+        rescue
+          raise CityCodeException.new
+        end
+
+        begin
+          url = URI.parse("https://wxtech.weathernews.com/opendata/v1/pollen?")
+          url.query = "citycode=#{city_code}&start=#{date.strftime("%Y%m%d")}&end=#{date.strftime("%Y%m%d")}"
+          res = Net::HTTP.get(url)
+          result = CSV.parse(res, headers: true)
+        rescue
+          raise PollenException.new
+        end
+
+        # データの提供元にてリザルトコードの扱いが示されていなかったため，正しくデータを取得できているか確認する
+        return nil unless result[0]
+        return Swimmy::Resource::Pollen.new(
+                 address,
+                 date,
+                 result[date.strftime("%H").to_i - 1]["pollen"].to_i)
+      end
+
+    end # class Pollen
+  end # module Service
+end # module Swimmy


### PR DESCRIPTION
# 概要
pollenコマンドの実装
## 変更点

- lib/swimmy/command 以下に pollen.rb を追加
- lib/swimmy/service 以下に pollen_service.rb を追加
- lib/swimmy/service 以下に city_code.rb を追加
- lib/swimmy/resource 以下に pollen_resource.rb を追加
- lib/swimmy/service.rb を pollen_service.rb に定義している Pollen クラスを読み込むように変更
- lib/swimmy/service.rb を city_code.rb に定義している CityCode クラスを読み込むように変更
- lib/swimmy/resource.rb を pollen_resource.rb に定義している Pollen クラスを読み込むように変更

コードレビューで頂いたアドバイスを受けて，コードの修正をしました．

# コマンドの概要

## 機能
指定した市区町村の1時間前の花粉情報を表示する．
## 使用方法
- Slack の nomlab ワークスペースで `swimmy pollen` と入力して岡山市北区の1時間前までの花粉情報を表示する．
- Slack の nomlab ワークスペースで `swimmy pollen <place>` と入力して指定した place の1時間前までの花粉情報を表示する．
## 特徴
-都道府県コードと市区町村コードを ExcelAPI から取得するにあたり，非同期処理で実装している． 