### PR TITLE
Add bookmark command

### DIFF
--- a/lib/swimmy/command/bookmark.rb
+++ b/lib/swimmy/command/bookmark.rb
@@ -1,0 +1,79 @@
+module Swimmy
+    module Command
+      class Bookmark < Swimmy::Command::Base
+  
+        command "bookmark" do |client, data, match|
+          if match[:expression]
+            arg = match[:expression].split(" ")
+            if arg.length < 2
+              msg = "コマンドが正しくありません．helpで確認してください．\n"
+              client.say(channel: data.channel, text: msg)
+              next
+            end
+            sub_command = arg[0]
+            url = arg[1]
+            title = arg[2..-1].join(" ")
+            target = arg[1..-1].join(" ")
+          end
+          usr = client.web_client.users_info(user: data.user).user.profile.display_name
+          bookmark = Swimmy::Service::Bookmark.new(spreadsheet)
+          case sub_command
+          when "add"
+            begin
+              entry = Swimmy::Resource::BookmarkEntry.new(usr, url, title)
+            rescue Swimmy::Resource::BookmarkEntry::InvalidTitleException
+              msg = "数字のみのタイトルをつけることはできません．\n" 
+              client.say(channel: data.channel, text: msg)
+              next
+            end
+            unless bookmark.exist?(entry)
+              bookmark.add(entry)
+              msg = "URLをブックマークに登録しました．\n"
+            else
+              msg = "対象のURLは既にブックマークに登録されています．\n"
+            end
+          when "delete"
+            if target =~ /\A[1-9][0-9]*\z/
+              num = target.to_i - 1
+              entry = bookmark.search_by_index(usr, num)
+            else
+              entry = bookmark.search_by_url_or_title(usr, target)
+            end
+            if entry == nil
+              msg = "削除対象が存在しません．\n"
+            else
+              bookmark.delete(entry)
+              msg = "URLをブックマークから削除しました．\n"
+            end
+          when nil
+            user_bookmark = bookmark.find_bookmark_by_user_name(usr)
+            msg = "#{usr}さんのブックマークを表示します．\n"
+            if user_bookmark == []
+              msg << "ブックマークが存在しません．\n"
+            end
+            user_bookmark.each_with_index do |row, index|
+              if row.title == ""
+                msg << "#{index + 1}．#{row.url}\n"
+              else
+                msg << "#{index + 1}．#{row.title}: #{row.url}\n"
+              end
+            end
+          else
+            msg = "コマンドが正しくありません．helpで確認してください．\n"
+          end
+          client.say(channel: data.channel, text: msg)
+        end
+  
+        help do
+          title "bookmark"
+          desc "指定したURLをブックマークに登録します"
+          long_desc "bookmark\n" +
+                    "現在登録されているブックマークを全件表示します．\n" +
+                    "bookmark add URL [TITLE]\n" +
+                    "URLをブックマークに登録します．\n" +
+                    "bookmark delete URL|TITLE|INDEX\n" +
+                    "指定したURL|TITLE|INDEXにmacthするブックマークを削除します．INDEXは全件表示から確認できます．\n"
+        end
+      end # class Bookmark
+    end # module command
+  end # module swimmy

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -20,5 +20,6 @@ module Swimmy
     autoload :CoopShop,         "#{dir}/coop_info.rb"
     autoload :NomnichiArticle,  "#{dir}/nomnichi_article.rb"
     autoload :CookResource, "#{dir}/cook_resource.rb"
+    autoload :BookmarkEntry, "#{dir}/bookmark.rb"
   end
 end

--- a/lib/swimmy/resource/bookmark.rb
+++ b/lib/swimmy/resource/bookmark.rb
@@ -1,0 +1,36 @@
+module Swimmy
+  module Resource
+    class BookmarkEntry
+
+      class InvalidTitleException < StandardError; end
+
+      attr_accessor :user_name, :url, :title, :active
+      attr_reader :id
+  
+      def initialize(user_name, url, title, active = true, id = nil)
+        if title =~ /\A[1-9][0-9]*\z/
+          raise InvalidTitleException.new
+        end
+        @user_name = user_name
+        @url = url
+        @title = title
+        @active = (active == "true" || active == true)
+        @id = id || SecureRandom.uuid
+      end
+      
+      def to_a
+        [
+          @user_name,
+          @url,
+          @title,
+          @active ? "true" : "false",
+          @id
+        ]
+      end
+  
+      def disable
+        return BookmarkEntry.new(@user_name, @url, @title, false)
+      end # class BookmarkEntryWithUID
+    end # class BookmarkEntry
+  end # module Resource
+end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -18,5 +18,6 @@ module Swimmy
     autoload :Coop, "#{dir}/coop.rb"
     autoload :Nomnichi, "#{dir}/nomnichi.rb"
     autoload :RecipeInfomation, "#{dir}/recipe_information.rb"
+    autoload :Bookmark, "#{dir}/bookmark.rb"
   end
 end

--- a/lib/swimmy/service/bookmark.rb
+++ b/lib/swimmy/service/bookmark.rb
@@ -1,0 +1,40 @@
+module Swimmy
+  module Service
+    class Bookmark
+
+      def initialize(spreadsheet)
+        @sheet = spreadsheet.sheet("bookmark", Swimmy::Resource::BookmarkEntry)
+        @row = @sheet.fetch
+        @active = @row.select { |row| row.active == true }
+      end
+
+      def exist?(bookmark_entry)
+        return @active.any?{|row| row.user_name == bookmark_entry.user_name && row.url == bookmark_entry.url}
+      end
+
+      def search_by_index(user, index)
+        bookmark = @active.select{|row| row.user_name == user}
+        return bookmark[index]
+      end
+
+      def search_by_url_or_title(user, word)
+        return @active.find{|row| row.user_name == user && (row.url == word || row.title == word)}
+      end
+
+      def add(bookmark_entry)
+        @sheet.append_row(bookmark_entry)
+      end
+
+      def delete(bookmark_entry)
+        row_num = @row.index(bookmark_entry) + 2
+        disable_entry = bookmark_entry.disable
+        @sheet.update_row(disable_entry, row_num)
+      end
+
+      def find_bookmark_by_user_name(user)     
+        list = @active.select{|row| row.user_name == user}
+        return list
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
bookmark コマンドの追加

# コマンドの概要

## 機能
よく閲覧する URL のブックマークを追加，削除，表示をする．

## 使用方法
`swimmy bookmark` と入力すると，入力したユーザの登録しているブックマークを全件表示する．
`swimmy bookmark add <URL> <title>` と入力すると，URL を title と名付けてブックマークに登録できる．title がない場合，無題として登録される．
`swimmy bookmark delete <target>`と入力すると，target で指定した番号，タイトル，URL のいずれかでマッチしたブックマークを削除する． 

## 特徴
Sheetq を介して Google Sheets を使用して，ユーザごとにブックマークを管理している．