### PR TITLE
Add cook command

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,5 @@ OPENHAB_URL=http://openhab.example.com
 # Use in news.rb
 NEWS_API_KEY=ThisIsSampleAPIKeyj985uYheRgw53IHuhs9OOindbrv6atResi
 
+# Use in cook.rb
+RAKUTEN_COOK_ID=ThisIsSampleSwimmyCookIDkfjgikdjrmkhfgc

--- a/lib/swimmy/command/cook.rb
+++ b/lib/swimmy/command/cook.rb
@@ -1,0 +1,38 @@
+module Swimmy
+  module Command
+    class Cook < Swimmy::Command::Base
+
+      class NonExistentException < StandardError; end
+
+      command "cook" do|client, data, match|
+
+        client.say(channel: data.channel, text: "レシピ情報を取得しています……")
+
+        begin
+          food = match[:expression] || ""
+          rakuten_app_id = ENV['RAKUTEN_COOK_ID']
+          if rakuten_app_id.nil?
+            message = "APIのIDが設定されていません．"
+          else
+            recipe_info = Service::RecipeInfomation.new(rakuten_app_id).get_recipeinfo(food)
+
+            message = if recipe_info then recipe_info.to_s else "レシピが見つかりませんでした．別のキーワードで再検索してください．" end
+          end
+        rescue => e
+          message = "通信に失敗しました．"
+        end
+
+        client.say(channel: data.channel, text: message)
+      end
+
+      help do
+        title "cook"
+        desc "指定した食べ物に対応したレシピを表示します．"
+        long_desc   "cook \n" +
+          "ランダムで選択したカテゴリのランキング1位のレシピを表示します． \n" +
+          "cook <食べ物名>\n" +
+          "指定した食べ物のランキング1位のレシピを表示します．"
+      end
+    end
+  end
+end

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -19,5 +19,6 @@ module Swimmy
     autoload :OpenhabMetadata, "#{dir}/openhab_metadata.rb"
     autoload :CoopShop,         "#{dir}/coop_info.rb"
     autoload :NomnichiArticle,  "#{dir}/nomnichi_article.rb"
+    autoload :CookResource, "#{dir}/cook_resource.rb"
   end
 end

--- a/lib/swimmy/resource/cook_resource.rb
+++ b/lib/swimmy/resource/cook_resource.rb
@@ -1,0 +1,18 @@
+module Swimmy
+  module Resource
+    class CookResource
+      def initialize(name, description, url)
+        @name, @description, @url = name, description, url
+      end
+
+      def to_s
+        message = <<~EOS
+        #{@name}
+        #{@description}
+        #{@url}
+        EOS
+      end
+
+    end
+  end
+end

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -17,5 +17,6 @@ module Swimmy
     autoload :Newsapi, "#{dir}/newsapi.rb"
     autoload :Coop, "#{dir}/coop.rb"
     autoload :Nomnichi, "#{dir}/nomnichi.rb"
+    autoload :RecipeInfomation, "#{dir}/recipe_information.rb"
   end
 end

--- a/lib/swimmy/service/recipe_information.rb
+++ b/lib/swimmy/service/recipe_information.rb
@@ -1,0 +1,160 @@
+require "json"
+require "uri"
+require 'open-uri'
+
+module Swimmy
+  module Service
+    class Category
+      attr :name, :id
+
+      def initialize(name, id)
+        @name = name
+        @id = id
+      end
+    end
+
+    class RecipeInfomation
+
+      class HttpException < StandardError; end
+
+      def initialize(api_id)
+        @api_id = api_id
+      end
+
+      def get_recipeinfo(food)
+        begin
+          category_list = CookCategory.new(@api_id).get_category_list
+        rescue
+          raise HttpException.new
+        end
+
+        begin
+          recipe_ranking = get_recipe_ranking(food, category_list)
+          return nil if recipe_ranking.nil?
+        rescue
+          raise HttpException.new
+        end
+
+        top_ranking = recipe_ranking["result"][0]
+        title = top_ranking["recipeTitle"]
+        description = top_ranking["recipeDescription"]
+        url = top_ranking["recipeUrl"]
+
+        recipe_info = Resource::CookResource.new(title, description, url)
+
+        return recipe_info
+      end
+
+      private
+      def get_recipe_ranking(food, category_list)
+        category_candidates = category_list.find_all{|c| c.name.include?(food)}
+        return nil if category_candidates.empty?
+        random_category = category_candidates.sample()
+        # assigns the Id of a random category among the categories matching the argument
+
+        begin
+          ranking_url = "https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426?format=json&categoryId=#{random_category.id}&applicationId=" + @api_id
+          # API仕様 : https://webservice.rakuten.co.jp/documentation/recipe-category-ranking
+          recipe_ranking = JSON.parse(URI.open(ranking_url, &:read))
+        rescue => e
+          p e
+          raise HttpException.new
+        end
+
+        return recipe_ranking
+      end
+    end
+
+    class CookCategory
+
+      # 楽天カテゴリランキングAPIから得られるJSONを変換したRubyオブジェクトは例えば以下のようになっている
+
+      # {"result"=>
+      #   {"large"=>
+      #     [{"categoryId"=>"10",
+      #       "categoryName"=>"肉",
+      #       ...
+      #     ],
+      #    "medium"=>
+      #     [{"categoryId"=>275,
+      #       "categoryName"=>"牛肉",
+      #       "parentCategoryId"=>"10"},
+      #      {"categoryId"=>67,
+      #       "categoryName"=>"ハム",
+      #       "parentCategoryId"=>"10"},
+      #       ...
+      #     ],
+      #    "small"=>
+      #     [{"categoryId"=>516,
+      #       "categoryName"=>"牛肉薄切り",
+      #       "parentCategoryId"=>"275"},
+      #      {"categoryId"=>1491,
+      #       "categoryName"=>"生ハム",
+      #       "parentCategoryId"=>"67"},
+      #       ...
+      #     ]
+      #   }
+      # }
+
+      # 楽天のAPIを用いてレシピのランキングを得るためにはカテゴリの ID が必要になる．
+      # categoryName と，それに対応する categoryID を取り出してハッシュを作成する．
+      # 上記のような例に対しては，以下のようなハッシュが作成される．
+      # {"肉"=>"10",
+      #  "牛肉"=>"10-275",
+      #  "ハム"=>"10-67",
+      #  "牛肉薄切り"=>"10-275-516",
+      #  "生ハム"=>"10-67-1491",
+      #  ...
+      # }
+      # 例えば生ハムというカテゴリのIDは"10-67-1491"となる．
+      # parentCategoryId を基に親カテゴリを探索し，その親カテゴリの categoryId を取得する．
+      # さらに親の親のカテゴリがある場合は，親カテゴリの parentCategoryId を基に更に親の親のカテゴリの categoryId を取得する．
+
+      def initialize(api_id)
+        @api_id = api_id
+      end
+
+      def get_category_list
+        begin
+          category_url = "https://app.rakuten.co.jp/services/api/Recipe/CategoryList/20170426?format=json&applicationId=" + @api_id
+          # API仕様 : https://webservice.rakuten.co.jp/documentation/recipe-category-list
+          result = JSON.parse(URI.open(category_url, &:read))
+        rescue => e
+          raise HttpException.new
+        end
+
+        category_id_hash = {}
+
+        ["large","medium","small"].each do |s|
+          result["result"][s].each do |entry|
+            category_id_hash[entry["categoryName"]] = get_my_id(result, entry, s)
+          end
+        end
+
+        return category_id_hash.map { |name, id|
+          Category.new(name, id)
+        }
+      end
+
+      def get_my_id(result, entry, categorytype)
+        return get_parent_id(result, entry, categorytype) + entry["categoryId"].to_s
+      end
+
+      def get_parent_id(result, entry, categorytype)
+        return "" if categorytype == "large"
+
+        parent_categorytype = if categorytype == "small"
+          "medium"
+        else
+          "large"
+        end
+
+        result["result"][parent_categorytype].each do |parent_entry|
+          return get_parent_id(result, parent_entry, parent_categorytype) + parent_entry["categoryId"].to_s + "-" if parent_entry["categoryId"].to_s == entry["parentCategoryId"]
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
# 概要
cook コマンドの追加

# コマンドの概要

## 機能
指定された食材や料理に適したレシピの情報を表示する．

## 使用方法
`swimmy cook <キーワード>` と入力するとキーワードに適したレシピを表示する．
`swimmy cook` と入力するとランダムにレシピを表示する．

## 特徴
[楽天レシピカテゴリ一覧API](https://webservice.rakuten.co.jp/documentation/recipe-category-list)と[楽天レシピカテゴリ別ランキングAPI](https://webservice.rakuten.co.jp/documentation/recipe-category-ranking)を使用している．