### PR TITLE
Fix handling nomnichi's HTTP request by ignoring SSL verification

### DIFF
--- a/lib/swimmy/command/nomnichi.rb
+++ b/lib/swimmy/command/nomnichi.rb
@@ -51,7 +51,7 @@ module Swimmy
         end
 
         def fetch_nomnichi_articles
-          Sheetq::Service::Nomnichi.new.fetch
+          Swimmy::Service::Nomnichi.new.fetch
         end
 
         def fetch_candidates(current_member_account_names, articles)

--- a/lib/swimmy/resource.rb
+++ b/lib/swimmy/resource.rb
@@ -18,5 +18,6 @@ module Swimmy
     autoload :Pollen,      "#{dir}/pollen_resource.rb"
     autoload :OpenhabMetadata, "#{dir}/openhab_metadata.rb"
     autoload :CoopShop,         "#{dir}/coop_info.rb"
+    autoload :NomnichiArticle,  "#{dir}/nomnichi_article.rb"
   end
 end

--- a/lib/swimmy/resource/nomnichi_article.rb
+++ b/lib/swimmy/resource/nomnichi_article.rb
@@ -1,0 +1,43 @@
+module Swimmy
+    module Resource
+      class NomnichiArticle
+        attr_reader :id, :user_id, :title, :perma_link, :content,
+        :published_on, :approved, :count, :promote_headline, :url
+  
+        def self.parse_hash(hash)
+          self.new(
+            hash["id"],
+            hash["user_id"],
+            hash["title"],
+            hash["perma_link"],
+            hash["content"],
+            DateTime.parse(hash["published_on"]).to_time,
+            hash["approved"],
+            hash["count"],
+            hash["promote_headline"],
+            hash["url"])
+        end
+  
+        def initialize(id, user_id, title, perma_link, content,
+                       published_on, approved, count, promote_headline, url)
+  
+          @id, @user_id, @title, @perma_link, @content,
+          @published_on, @approved, @count, @promote_headline,
+          @url =id, user_id, title, perma_link, content,
+          published_on, approved, count, promote_headline, url
+        end
+  
+        # Since we have no way to aquire user_name from JSON,
+        # get it from `perma_link`:
+        #   "yoshida-s-20181116-132016" => yoshida-s
+        #
+        def user_name
+          if /(.*)-\d{8}-\d{6}$/ =~ perma_link
+            return $1
+          else
+            return "unknown"
+          end
+        end
+      end # class NomnichiArticle
+    end # module Resource
+  end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -16,6 +16,6 @@ module Swimmy
     autoload :Openhab, "#{dir}/openhab.rb"
     autoload :Newsapi, "#{dir}/newsapi.rb"
     autoload :Coop, "#{dir}/coop.rb"
-
+    autoload :Nomnichi, "#{dir}/nomnichi.rb"
   end
 end

--- a/lib/swimmy/service/nomnichi.rb
+++ b/lib/swimmy/service/nomnichi.rb
@@ -1,0 +1,27 @@
+module Swimmy
+    module Service
+      class Nomnichi
+        def fetch(max_page = 10)
+          require "json"
+          require "net/http"
+          base_url = "https://gc.cs.okayama-u.ac.jp/lab/nom/articles.json?page="
+          page, articles = 1, []
+  
+          loop do
+            return articles if page > max_page
+            uri = URI.parse(base_url)
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE # SSL証明書を無視
+            req = Net::HTTP::Get.new(uri.path + "?" + uri.query + page.to_s)
+            res = http.request(req)
+
+            return articles if res.code != "200" # no more articles
+            articles += JSON.parse(res.body).map {|hash| Swimmy::Resource::NomnichiArticle.parse_hash(hash)}
+            return articles if Time.now - articles.last.published_on > (365*24*60*60) # limit to 1-year
+            page += 1
+          end
+        end
+      end # Nomnichi
+    end # Service
+  end # module Swimmy


### PR DESCRIPTION
## 概要
+ nomnichi のデプロイ先の変更による URL の変更に対応した．
+ swimmy の nomnichi コマンドが Sheetq の Resourse ファイルと Service ファイルに依存していたため，Resourse ファイルと Service ファイルを swimmy に移行した．

## 変更点
+ リクエスト先の URL を変更した．
+ SSL 証明書を無視する設定とそれに伴うメソッドを変更した．
+ Sheetq の Resourse ファイルと Service ファイルを移行した．