### PR TITLE
Fix a bug that uploading multiple photos fails

### DIFF
--- a/lib/swimmy/command/photo_upload.rb
+++ b/lib/swimmy/command/photo_upload.rb
@@ -19,8 +19,7 @@ module Swimmy
           data.files.each do |file|
             next unless ["jpg", "png"].include?(file.filetype)
             client.say(channel: data.channel, text: "Google Photos にアップロード中 (#{file.name})...")
-
-            Thread.new do
+            begin
               google_oauth ||= begin
                   Swimmy::Resource::GoogleOAuth.new(GOOGLE_CREDENTIAL_PATH, GOOGLE_TOKEN_PATH)
                 rescue => e


### PR DESCRIPTION
## 概要
一つのメッセージに複数の写真がある場合，2枚目以降の写真のアップロードが必ず失敗するバグを修正した．

## 原因
写真のアップロード処理をスレッドを用いて並列化していたが，Google Photos は同時に写真がアップロードされると "429 Too Many Requests" を返すことが原因．

## 修正方法
複数の写真がある場合，一枚ずつブロッキング処理でアップロードするように変更．