### PR TITLE
Update attendance command to be able to execute with a user name.

### DIFF
--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -9,9 +9,39 @@ module Swimmy
 
         cmd = match[:command]
         now = Time.now
-        user = client.web_client.users_info(user: data.user).user
-        user_id = user.id
-        user_name = user.profile.display_name
+
+        # if no argument
+        if !match[:expression]
+          user = client.web_client.users_info(user: data.user).user
+          user_id = user.id
+          user_name = user.profile.display_name
+
+        # if with argument
+        else
+          args = match[:expression].split
+          # if with one argument
+          if args.length == 1
+            # fetch active members from nompedia
+            active_members = spreadsheet.sheet("members", Swimmy::Resource::Member).fetch.select {|m| m.active? }.map {|m| m.account }
+
+            # judge if the person specified in the argument is active
+            if active_members.include?(args[0])
+              user = client.web_client.users_info(user: data.user).user
+              user_id = user.id
+              user_name = args[0]
+            else
+              # if not active, print error message
+              msg = "ユーザ #{args[0]}は現役メンバではありません．"
+              client.say(channel: data.channel, text: msg)
+              next
+            end
+          # if with two or more arguments, print error message
+          elsif args.length >= 2
+            msg = "引数は1つしか設定できません．\n"
+            client.say(channel: data.channel, text: msg)
+            next
+          end
+        end
 
         # log to spreadsheet
         now_s = now.strftime("%Y-%m-%d %H:%M:%S")
@@ -36,7 +66,9 @@ module Swimmy
         title "attendance"
         desc "hi/bye で入退室をスプレッドシートに記録し，ドアプレートを更新します"
         long_desc "attendance (hi|bye)\n" +
-                  "もしくは，メンションで hi/bye だけでも OK です．"
+                  "もしくは，メンションで hi/bye だけでも OK です．\n" +
+                  "attendance (hi|bye) [MEMBER]\n" +
+                  "[MEMBER] を指定して，attendance コマンドを実行します"
       end
     end # class Attendance
   end # module Command


### PR DESCRIPTION
# 概要
+ attendance コマンドを，引数でユーザ名を指定して実行できるようにアップデートした．
  + 引数が指定された場合，そのユーザ名で attendance コマンドを実行する．このとき，指定されたユーザ名が現役メンバのものでない場合や，引数が2つ以上指定された場合は，attendance コマンドは失敗し，エラーメッセージを出力する．
  + 引数が指定されなかった場合，従来どおり，コマンドの発言者のユーザ名で attendance コマンドを実行する．
+ また，上記に伴い，help コマンドで表示するヘルプメッセージをアップデートした．

