### PR TITLE
Add loc command

### DIFF
--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -1,0 +1,57 @@
+# hi         在室
+# lec        講義
+# meet       打合
+# oncampus   学内
+# offcampus  学外
+# bye        帰宅
+
+module Swimmy
+  module Command
+    class Location < Swimmy::Command::Base
+      # command 'hi', 'lec', 'meet', 'on', 'off', 'bye' do |client, data, match|
+      command 'location' do |client, data, match|
+        user = client.web_client.users_info(user: data.user).user
+        user_id = user.id
+        user_name = user.profile.display_name
+        location_list = ["hi", "lec", "meet", "oncampus", "offcampus", "bye"]
+        arg = match[:expression] # arg.class=>string
+
+        # 引数が指定される場合
+        if arg
+          # 引数が正しい場合
+          if location_list.include?(arg)
+            # client.say(channel: data.channel, text:"arg: #{arg}")
+          # 引数の数が正しくない場合
+          elsif arg.split.length != 1
+            client.say(channel: data.channel, text: "引数の数が正しくありません．")
+            return;
+          # 引数に誤った入力がされた場合
+          else 
+            client.say(channel: data.channel, text: "引数の値が正しくありません．")
+            return;
+          end
+        # 引数が指定されない場合
+        else 
+          client.say(channel: data.channel, text: "引数を指定してください．")
+          return;
+        end
+
+        begin
+          # 現在地をMQTTでpublish
+          # client.say(channel: data.channel, text: "更新確認")
+          doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
+          doorplate_service.send_attendance_event(arg, user_id, user_name)
+        rescue Exception => e
+          client.say(channel: data.channel, text: "ドアプレートを更新できませんでした．")
+          raise e
+        end
+
+        client.say(channel: data.channel, text: "ドアプレートを更新しました．")
+      end
+
+      # help do
+
+      # end
+    end
+  end
+end

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -1,17 +1,39 @@
 module Swimmy
   module Command
     class Location < Swimmy::Command::Base
-      # command 'hi', 'lec', 'meet', 'on', 'off', 'bye' do |client, data, match|
       command 'location' do |client, data, match|
         user = client.web_client.users_info(user: data.user).user
         user_id = user.id
         user_name = user.profile.display_name
-        arg = match[:expression] # arg.class=>string
+        arg = match[:expression]
         
+        # 引数が指定されていない場合
+        if arg.nil? || arg.empty?
+          client.say(channel: data.channel,
+                        text: "引数が指定されていません．\n")
+          return
+        end
+
         # 部屋番号によって指定できる所在を変更する
-        # 他の実装は可能?
-        location_list_106 = ["hi", "lec", "meet", "campus", "outside", "bye"]
-        location_list_206 = ["hi", "meet", "lab", "lec", "dept", "campus", "miss", "bye"]
+        # location_list_106 = ["hi", "lecture", "meeting", "campus", "outside", "bye"]
+        # location_list_206 = ["hi", "meeting", "laboratory", "lecture", "departmemt", "campus", "bye"]
+        location_list_106 = {
+                              "hi"      => "在室",
+                              "lecture" => "講義",
+                              "meeting" => "打合",
+                              "campus"  => "学内",
+                              "outside" => "学外", 
+                              "bye"     => "帰宅"
+                            }
+        location_list_206 = {
+                              "hi"         => "在室",
+                              "meeting"    => "オンライン講義・会議中",
+                              "laboratory" => "研究室(105・106)",
+                              "lecture"    => "講義室",
+                              "departmemt" => "学科内",
+                              "campus"     => "大学内",
+                              "bye"        => "帰宅・出張"
+                            }
         case user_name
         when "nom"
           location_list = location_list_206
@@ -19,25 +41,43 @@ module Swimmy
           location_list = location_list_106
         end
 
-        
-        if arg && location_list.include?(arg)
-          # 引数が正しく指定される場合
-          begin
-            # MQTTブローカにpublish
-            doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-            doorplate_service.send_attendance_event(arg, user_id, user_name)
-          rescue Exception => e
-            client.say(channel: data.channel, text: "ドアプレートを更新できませんでした．")
-            raise e
+        # 引数の先頭が一致する所在を取得する
+        prefix_match_list = retrieve_complement_location_list(arg, location_list)
+
+        # 引数で指定した文字列から始まる所在の数を判定
+        if prefix_match_list.length > 1
+          # 引数で指定した文字列が複数の所在にマッチする場合
+          client.say(channel: data.channel,
+                        text: "指定された文字列に該当する所在が複数見つかりました．\n")    
+          min_prefix_list = get_min_prefix_list(prefix_match_list.keys)
+          prefix_match_list.each do |key, value|
+            client.say(channel: data.channel,
+                          text: "#{key}, #{value}, #{min_prefix_list[key]}")
           end
-          client.say(channel: data.channel, text: "ドアプレートを更新しました．")
-        else
-          # 引数が正しく入力されない場合(値が不正，引数がない，引数が2つ以上) 
-          say_wrong_arg(client, data)
-          break;
+          return
+        elsif prefix_match_list.length == 0
+          # 引数で指定した文字列が所在にマッチしない場合
+          client.say(channel: data.channel,
+                        text: "指定された文字列に該当する所在は見つかりませんでした．\n")
+          return
         end
+        
+        client.say(channel: data.channel,
+                        text: "#{prefix_match_list.keys.first}")
+        # 引数で指定した文字列が1つの所在にマッチする場合
+        begin
+          # MQTTブローカにpublish
+          doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
+          doorplate_service.send_attendance_event(prefix_match_list.keys.first, user_id, user_name)
+        rescue Exception => e
+          client.say(channel: data.channel, text: "ドアプレートを更新できませんでした．")
+          raise e
+        end
+        client.say(channel: data.channel, text: "ドアプレートを更新しました．")
       end
 
+      ################################################################################
+      # TODO: help, self_say.wrong_arg の内容を変更する
       help do
         title "location"
         desc "ドアプレートの状態を変更します．"
@@ -46,25 +86,25 @@ module Swimmy
                   "指定できる<所在>は以下のいずれかです．\n\n" +
                   "106号室\n" +
                   "hi :                   在室\n" +
-                  "lec :                 講義\n" +
-                  "meet :             打合\n" +
+                  "lecture :                 講義\n" +
+                  "meeting :             打合\n" +
                   "campus :        学内\n" +
                   "outside :        学外\n" +
                   "bye :                帰宅\n\n" +
                   +
                   "206号室\n" +
                   "hi :                   在室\n" +
-                  "meet :            オンライン講義・会議中\n" +
-                  "lab :                 研究室(105・106)\n" +
-                  "lec :                 講義室\n" +
-                  "dept :              学科内\n" +
+                  "meeting :            オンライン講義・会議中\n" +
+                  "laboratory :                 研究室(105・106)\n" +
+                  "lecture :                 講義室\n" +
+                  "department :              学科内\n" +
                   "campus :        大学内\n" +
-                  "miss :              行方不明\n" +
                   "bye :                帰宅・出張\n" +
                   "\n引数は1つだけ指定してください．\n" # 出力のインデント調整のために空白を入れています
       end
 
-
+      ################################################################################
+      # Helper Functions
       def self.say_wrong_arg(client, data)
         client.say(channel: data.channel,
                   text: "引数が正しく入力されていません．\n" +
@@ -76,7 +116,6 @@ module Swimmy
                         "campus :        学内\n" +
                         "outside :        学外\n" +
                         "bye :                帰宅\n\n" +
-                        +
                         "206号室\n" +
                         "hi :                   在室\n" +
                         "meet :            オンライン講義・会議中\n" +
@@ -88,6 +127,40 @@ module Swimmy
                         "bye :                帰宅・出張\n" # 出力のインデント調整のために空白を入れています
         )
       end
+
+      # 所在リストから prefix で始まる所在を取得する
+      def self.retrieve_complement_location_list(prefix, location_list)
+        prefix_match_list = Hash::new
+        location_list.each do |key, value|
+          if key.start_with?(prefix) 
+            prefix_match_list[key] = value
+          end
+        end
+        return prefix_match_list
+      end
+
+      # 各 key を一意に識別できる最小の prefix を取得する
+      def self.get_min_prefix_list(location_keys)
+        result = Hash::new
+  
+        location_keys.each do |key|
+          min_prefix = key
+          others = location_keys.each.reject { |k| k == key }  # 自分以外にこの prefix から始まるものがあるかチェック
+          (1..key.length).each do |prefix_len|
+            prefix = key[0, prefix_len]
+            conflict = others.any? { |k| k.start_with?(prefix) }  # プレフィックスの衝突判定
+      
+            # 衝突が発生しなければリストに追加し終了
+            unless conflict
+              min_prefix = prefix
+              break
+            end
+          end
+          result[key] = min_prefix
+        end
+        return result
+      end
+
     end
   end
 end

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -23,18 +23,22 @@ module Swimmy
             # client.say(channel: data.channel, text:"arg: #{arg}")
           # 引数の数が正しくない場合
           elsif arg.split.length != 1
-            client.say(channel: data.channel, text: "引数の数が正しくありません．")
+            # client.say(channel: data.channel, text: "引数の数が正しくありません．")
+            say_wrong_arg(client, data)
             return;
           # 引数に誤った入力がされた場合
           else 
-            client.say(channel: data.channel, text: "引数の値が正しくありません．")
+            # client.say(channel: data.channel, text: "引数の値が正しくありません．")
+            say_wrong_arg(client, data)
             return;
           end
         # 引数が指定されない場合
         else 
-          client.say(channel: data.channel, text: "引数の数が正しくありません．")
+          # client.say(channel: data.channel, text: "引数の数が正しくありません．")
+          say_wrong_arg(client, data)
           return;
         end
+        
 
         begin
           # 現在地をMQTTでpublish
@@ -49,9 +53,33 @@ module Swimmy
         client.say(channel: data.channel, text: "ドアプレートを更新しました．")
       end
 
-      # help do
+      help do
+        title "location"
+        desc "ドアプレートの状態を変更します．"
+        long_desc "location <所在>\n" +
+                  "ドアプレートの状態を指定した<所在>に変更します．\n" +
+                  "指定できる<所在>は以下の6つです．\n" +
+                  "hi :                   在室\n" +
+                  "lec :                 講義\n" +
+                  "meet :             打合\n" +
+                  "oncampus :   学内\n" +
+                  "offcampus :   学外\n" +
+                  "bye :                帰宅\n" +
+                  "引数は1つだけ指定してください．\n" 
+      end
 
-      # end
+
+      def self.say_wrong_arg(client, data)
+        client.say(channel: data.channel,
+                  text: "引数が正しく入力されていません．\n" +
+                        "引数は 以下から1つだけ指定してください．\n\n" +
+                        "hi :                   在室\n" +
+                        "lec :                 講義\n" +
+                        "meet :             打合\n" +
+                        "oncampus :   学内\n" +
+                        "offcampus :   学外\n" +
+                        "bye :                帰宅\n") # 出力のインデント調整のために空白を入れています
+      end
     end
   end
 end

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -69,57 +69,51 @@ module Swimmy
           doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
           doorplate_service.send_attendance_event(prefix_match_list.keys.first, user_id, user_name)
         rescue Exception => e
-          client.say(channel: data.channel, text: "ドアプレートを更新できませんでした．")
+          client.say(channel: data.channel, text: "ドアプレートの状態を更新できませんでした．")
           raise e
         end
-        client.say(channel: data.channel, text: "ドアプレートを更新しました．")
+        client.say(channel: data.channel, text: "ドアプレートの状態を #{prefix_match_list.values.first} に更新しました．")
       end
 
       ################################################################################
-      # TODO: help, self_say.wrong_arg の内容を変更する
       help do
         title "location"
-        desc "ドアプレートの状態を変更します．"
+        desc "ドアプレートの所在を変更します．"
         long_desc "location <所在>\n" +
                   "ドアプレートの状態を指定した<所在>に変更します．\n" +
                   "指定できる<所在>は以下のいずれかです．\n\n" +
                   "106号室\n" +
-                  "hi :                   在室\n" +
-                  "lecture :                 講義\n" +
-                  "meeting :             打合\n" +
-                  "campus :        学内\n" +
-                  "outside :        学外\n" +
-                  "bye :                帰宅\n\n" +
+                  "hi (h) : 在室\n" +
+                  "lecture (l) : 講義\n" +
+                  "meeting (m) : 打合\n" +
+                  "campus (c) : 学内\n" +
+                  "outside (o) : 学外\n" +
+                  "bye (b) : 帰宅\n\n" +
                   +
                   "206号室\n" +
-                  "hi :                   在室\n" +
-                  "meeting :            オンライン講義・会議中\n" +
-                  "laboratory :                 研究室(105・106)\n" +
-                  "lecture :                 講義室\n" +
-                  "department :              学科内\n" +
-                  "campus :        大学内\n" +
-                  "bye :                帰宅・出張\n" +
-                  "\n引数は1つだけ指定してください．\n" # 出力のインデント調整のために空白を入れています
+                  "hi (h) : 在室\n" +
+                  "meeting (m) : オンライン講義・会議中\n" +
+                  "laboratory (la) : 研究室(105・106)\n" +
+                  "lecture (le) : 講義室\n" +
+                  "department (d) : 学科内\n" +
+                  "campus (c) : 大学内\n" +
+                  "bye (b) : 帰宅・出張\n"
       end
 
       ################################################################################
       # Helper Functions
-      
+
       # 引数に関するヘルプ文を取得
       def self.message_location_help(location_list)
         # プレフィックスリストを作成
         prefix_list = get_min_prefix_list(location_list.keys)
 
-        max_location_len = get_max_len(location_list.keys)
-        max_state_len = get_max_len(location_list.values)
-        max_prefix_len = get_max_len(prefix_list.values)
-
         # TODO: puts -> client.say
         message = "引数を以下から1つを指定してください．\n\n" +
-                  "引数(最小入力) : 所在名\n"
+                  "引数(最小入力) :  所在名\n"
   
         location_list.each do |key, value|
-          message += "#{key.ljust(max_location_len)} (#{prefix_list[key].ljust(max_prefix_len)}) : #{value.ljust(max_state_len)}\n" 
+          message += "#{key} (#{prefix_list[key]}) :  #{value}\n"
         end
         return message
       end

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -32,7 +32,7 @@ module Swimmy
           end
         # 引数が指定されない場合
         else 
-          client.say(channel: data.channel, text: "引数を指定してください．")
+          client.say(channel: data.channel, text: "引数の数が正しくありません．")
           return;
         end
 

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -1,9 +1,10 @@
 # hi         在室
 # lec        講義
 # meet       打合
-# oncampus   学内
-# offcampus  学外
+# campus     学内
+# outside    学外
 # bye        帰宅
+
 
 module Swimmy
   module Command
@@ -13,33 +14,40 @@ module Swimmy
         user = client.web_client.users_info(user: data.user).user
         user_id = user.id
         user_name = user.profile.display_name
-        location_list = ["hi", "lec", "meet", "oncampus", "offcampus", "bye"]
+        location_list = ["hi", "lec", "meet", "campus", "outside", "bye"]
+        location_list_206 = ["hi", "meet", "lab", "lec", "dept", "campus", "miss", "bye"]
         arg = match[:expression] # arg.class=>string
 
         # 引数が指定される場合
         if arg
           # 引数が正しい場合
           if location_list.include?(arg)
-            # client.say(channel: data.channel, text:"arg: #{arg}")
-          # 引数の数が正しくない場合
-          elsif arg.split.length != 1
-            # client.say(channel: data.channel, text: "引数の数が正しくありません．")
-            say_wrong_arg(client, data)
-            return;
-          # 引数に誤った入力がされた場合
-          else 
-            # client.say(channel: data.channel, text: "引数の値が正しくありません．")
+                                        # 206号室を追加する場合，条件式に以下を加える．
+                                        # || location_list_206.include?(arg)
+          # # 引数の数が正しくない場合
+          # elsif arg.split.length != 1
+          #   # client.say(channel: data.channel, text: "引数の数が正しくありません．")
+          #   say_wrong_arg(client, data)
+          #   return;
+          # # 引数に誤った入力がされた場合
+          # else 
+          #   # client.say(channel: data.channel, text: "引数の値が正しくありません．")
+          #   say_wrong_arg(client, data)
+          #   return;
+          # end
+
+          # 引数の指定(数もしくは値)が正しくない場合
+          else
             say_wrong_arg(client, data)
             return;
           end
-        # 引数が指定されない場合
+        # 引数が入力されなかった場合
         else 
           # client.say(channel: data.channel, text: "引数の数が正しくありません．")
           say_wrong_arg(client, data)
           return;
         end
         
-
         begin
           # 現在地をMQTTでpublish
           # client.say(channel: data.channel, text: "更新確認")
@@ -58,14 +66,25 @@ module Swimmy
         desc "ドアプレートの状態を変更します．"
         long_desc "location <所在>\n" +
                   "ドアプレートの状態を指定した<所在>に変更します．\n" +
-                  "指定できる<所在>は以下の6つです．\n" +
+                  "指定できる<所在>は以下のいずれかです．\n\n" +
+                  "106号室\n" +
                   "hi :                   在室\n" +
                   "lec :                 講義\n" +
                   "meet :             打合\n" +
-                  "oncampus :   学内\n" +
-                  "offcampus :   学外\n" +
-                  "bye :                帰宅\n" +
-                  "引数は1つだけ指定してください．\n" 
+                  "campus :        学内\n" +
+                  "outside :        学外\n" +
+                  "bye :                帰宅\n\n" +
+                  +
+                  "206号室\n" +
+                  "hi :                   在室\n" +
+                  "meet :            オンライン講義・会議中\n" +
+                  "lab :                 研究室(105・106)\n" +
+                  "lec :                 講義室\n" +
+                  "dept :              学科内\n" +
+                  "campus :        大学内\n" +
+                  "miss :              行方不明\n" +
+                  "bye :                帰宅・出張\n" +
+                  "\n引数は1つだけ指定してください．\n" # 出力のインデント調整のために空白を入れています
       end
 
 
@@ -73,12 +92,24 @@ module Swimmy
         client.say(channel: data.channel,
                   text: "引数が正しく入力されていません．\n" +
                         "引数は 以下から1つだけ指定してください．\n\n" +
+                        "106号室\n" +
                         "hi :                   在室\n" +
                         "lec :                 講義\n" +
                         "meet :             打合\n" +
-                        "oncampus :   学内\n" +
-                        "offcampus :   学外\n" +
-                        "bye :                帰宅\n") # 出力のインデント調整のために空白を入れています
+                        "campus :        学内\n" +
+                        "outside :        学外\n" +
+                        "bye :                帰宅\n\n" +
+                        +
+                        "206号室\n" +
+                        "hi :                   在室\n" +
+                        "meet :            オンライン講義・会議中\n" +
+                        "lab :                 研究室(105・106)\n" +
+                        "lec :                 講義室\n" +
+                        "dept :              学科内\n" +
+                        "campus :        大学内\n" +
+                        "miss :              行方不明\n" +
+                        "bye :                帰宅・出張\n" # 出力のインデント調整のために空白を入れています
+        )
       end
     end
   end


### PR DESCRIPTION
# 概要
loc コマンドの追加

# コマンドの概要
## 機能
ドアプレートの状態を引数で指定された所在に変更する．

## 使用方法
`swimmy loc <引数>` と入力するとドアプレートの状態を<引数>に対応した所在に変更する．
<引数>と所在の対応は以下のとおりである．

106号室
|引数|所在|
| ---- | ---- |
| hi | 在室 |
| lecture | 講義 |
| meeting | 打合 |
| campus | 学内 |
| outside | 学外 |
| bye | 帰宅 |

206号室
|引数|所在|
| ---- | ---- |
| hi | 在室 |
| meeting | オンライン講義・会議中 |
| laboratory | 研究室(105・106) |
| lecture | 講義室 |
| department | 学科内 |
| campus | 大学内 |
| bye | 帰宅・出張 |

<引数>には前方一致を許しており，
所在を識別できる最小の文字列を入力することで省略しない場合と同じ所在に変更できる．
たとえば，所在を``講義''に変更する場合は，
<引数>には" l "や " lec " を指定できる．

## 特徴
MQTT と openHAB を介して，ドアプレートの状態の変更を行っている．