### PR TITLE
Add karaoke_cmd

### DIFF
--- a/lib/swimmy/command/karaoke.rb
+++ b/lib/swimmy/command/karaoke.rb
@@ -1,0 +1,39 @@
+module Swimmy
+  module Command
+    class Karaoke < Swimmy::Command::Base
+      karaoke_service = Swimmy::Service::Karaoke.new("https://www.clubdam.com/ranking/")
+      
+      def self.say_ranking(client, data, song_ranking_hash, title)
+        text = "DAM カラオケ#{title}ランキング\n"
+        text += "引用元：https://www.clubdam.com/ranking/\n"
+        song_ranking_hash.each{|i, song| text += "#{i}位: #{song}\n"}                                       		
+        client.say(channel: data.channel, text: text)
+      end # say_ranking
+
+      command "karaoke" do |client, data, match|
+        case match[:expression]
+        when nil, ""
+          title, api_arg = "", "daily"
+        when "daily"
+          title, api_arg = "デイリー", "daily"
+        when "weekly"
+          title, api_arg = "ウィークリー", "weekly"
+        when "monthly"
+          title, api_arg = "マンスリー", "monthly"
+        else
+          client.say(channel: data.channel, text: "引数を間違えています．daily, weekly, monthly のいずれかまたは引数なしを入力してください")
+          return nil
+        end
+        ranking_list = karaoke_service.get_karaoke_info(api_arg)
+        Karaoke.say_ranking(client, data, ranking_list, title)
+      end # command do
+      help do
+        title "karaoke"
+        desc "DAMのカラオケデイリーランキングを表示する"
+        long_desc "karaoke daily - カラオケデイリーランキングを表示する\n" +
+                  "karaoke weekly - カラオケウィークリーランキングを表示する\n" +
+                  "karaoke monthly - カラオケマンスリーランキングを表示する"
+      end # help do
+    end # class Karaoke
+  end # module Command
+end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -19,5 +19,6 @@ module Swimmy
     autoload :Nomnichi, "#{dir}/nomnichi.rb"
     autoload :RecipeInfomation, "#{dir}/recipe_information.rb"
     autoload :Bookmark, "#{dir}/bookmark.rb"
+    autoload :Karaoke, "#{dir}/karaoke.rb"
   end
 end

--- a/lib/swimmy/service/karaoke.rb
+++ b/lib/swimmy/service/karaoke.rb
@@ -1,0 +1,63 @@
+# スクレイピング対象のwebサイトは例えば以下のようになっている
+
+# <div id="daily-ranking">
+#     <ul class="p-song-list p-ranking-list" data-defoult="10">
+
+# <li class="p-song-list__item p-ranking-list__item">
+#                 <div class="p-song-unit p-song-unit--ellipsis">
+# <a class="p-song-unit__sp-link" href="/karaokesearch/songleaf.html?requestNo=1447-11"></a><a class="p-song p-song--song p-ranking" href="/karaokesearch/songleaf.html?requestNo=1447-11">
+
+#                     <div class="p-ranking__num p-ranking__num--first">1</div>
+	
+#                     <div class="p-song__inner">
+# 	            	<div class="p-song__tieup">『忘却バッテリー』</div>
+#                       <h4 class="p-song__title">ライラック</h4>
+#                       <div class="p-song__artist">Mrs. GREEN APPLE</div>
+#                     </div>
+#                   </a><a class="p-song p-song--artist" href="/karaokesearch/artistleaf.html?artistCode=108199">
+#                     <div class="p-song__inner">
+#                       <div class="p-song__artist">Mrs. GREEN APPLE</div>
+#                     </div>
+#                   </a>
+# </div>
+#               </li>
+
+# 今回実装した手法では，ランキングの曲のみを取得する. 例えばデイリーランキングを取得するときは，
+# "daily-ranking"の中の"p-song-list__item p-ranking-list__item"というクラスを探索し，
+# 順位やタイトルが含まれているhtmlを取得する．次に，取得したhtmlから"p-ranking__num"，"p-song__title"
+# をというクラスをそれぞれ探索し，順位と曲のタイトルをそれぞれ取得する．
+
+require 'open-uri'
+require 'nokogiri'
+
+module Swimmy
+  module Service
+    class Karaoke
+      def initialize(url)
+        @url = url
+      end
+       
+      def get_karaoke_info(ranking_span, max_ranking=10)
+
+        song_ranking = {}                 
+        html = URI.open(@url).read
+        doc = Nokogiri::HTML.parse(html)
+
+        #"{ranking_span}-ranking"の中の"p-song-list__item p-ranking-list__item"というクラスを探索
+        #{ranking_span}にはdaily, weekly, monthlyのいずれかが入力される
+        # 例えばデイリーランキングを取得するときは，"daily-ranking"の中の"p-song-list__item p-ranking-list__item"
+        # というクラスを探索し，順位やタイトルが含まれているhtmlを取得する．
+        doc.xpath(%Q{//div[@id="#{ranking_span}-ranking"]//li[@class="p-song-list__item p-ranking-list__item"]}).each do |str|
+          # "p-ranking__num"，"p-song__title"をそれぞれ取得し，ranking_list,song_listに格納する．
+          ranking = str.xpath('.//div[contains(@class, "p-ranking__num")]').text.strip
+          song = str.xpath('.//h4[@class="p-song__title"]').text.strip
+          song_ranking[ranking] = song
+          if ranking.to_i == max_ranking
+            break
+          end
+        end
+        return song_ranking
+      end # get_karaoke_info
+    end # class Karaoke
+  end # module service
+end # module swimmy


### PR DESCRIPTION
# 概要
karaoke コマンドの追加

# コマンドの概要
## 機能
DAMのカラオケランキングを表示する．

## 使用方法
`swimmy karaoke [引数]` と入力すると[引数]に対応した期間のカラオケランキングを表示する．
[引数]と期間の対応は以下のとおりである．

|引数|期間|
| ---- | ---- |
| daily | デイリーランキング |
| weekly | ウィークリーランキング |
| monthly | マンスリーランキング |
| 引数なし | デイリーランキング | 


## 特徴
DAMの公式サイトからスクレイピングしてランキングを取得している．