### PR TITLE
add hizuki command

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,3 +23,6 @@ NEWS_API_KEY=ThisIsSampleAPIKeyj985uYheRgw53IHuhs9OOindbrv6atResi
 
 # Use in cook.rb
 RAKUTEN_COOK_ID=ThisIsSampleSwimmyCookIDkfjgikdjrmkhfgc
+
+# Use in translate.rb
+TRANSLATE_API_URL=ThisIsSampleSwimmyHizukiTranslateGAS

--- a/lib/swimmy/command/hizuki.rb
+++ b/lib/swimmy/command/hizuki.rb
@@ -1,0 +1,73 @@
+# coding: utf-8
+module Swimmy
+  module Command
+    class Hizuki < Swimmy::Command::Base
+      require 'date'
+      require 'json'
+      require 'uri'
+      require 'net/http'
+      
+      command "hizuki" do |client, data, match|
+
+        date_expr = /\A(\d+)\/(\d+)\Z/
+        year_expr = /\A([\+-]?\d+)\Z/
+        case match[:expression]
+        when date_expr
+          message = self.get_date_event_message($1.to_i, $2.to_i)
+        when year_expr
+          message = self.get_year_event_message($1.to_i)
+        when "help"
+          message = help_message("hizuki")
+        else
+          message = "run \"hizuki help\""
+        end
+
+        client.say(channel: data.channel, text: message)
+      end
+
+      help do
+        title "hizuki"
+        desc "  西暦や日付に関係する雑学を教えてくれます．"
+        long_desc "hizuki MM/DD - MM月DD日に関係する雑学を教えてくれます．\n" +
+                  "hizuki YYYY - 西暦YYYYに関係する雑学を教えてくれます．\n"  
+      end
+
+      def self.get_date_event_message(month=0, day=0)
+        return "#{month}/#{day} は存在しない日付です" if !Date.valid_date?(4, month, day)
+
+        numbersapi = Swimmy::Service::Numbersapi.new
+        en_text = numbersapi.fetch_date_event(month, day)
+        return "#{month}/#{day}に関する情報はありませんでした" if en_text.nil?
+
+        self.gen_message(en_text)
+      end
+
+      def self.get_year_event_message(year=0)
+        return "#{year}年は未来の年です" if year > Date.today.year
+        return "西暦0年は存在しません" if year==0
+
+        numbersapi = Swimmy::Service::Numbersapi.new
+        en_text = numbersapi.fetch_year_event(year)
+        if en_text.nil? then
+          era = if year < 0 then "紀元前#{-year}年" else "#{year}年" end
+          return "#{era}に関する情報はありませんでした" 
+        end
+        
+        self.gen_message(en_text)
+      end
+
+      def self.gen_message(en_text)
+        ja_text = Swimmy::Service::Translate.new("en", "ja").translate(en_text)
+        ja_text = if ja_text.nil? then "翻訳できませんでした" else ja_text end
+
+        text = <<~EOS 
+        [trivia]
+        #{en_text}
+        
+
+        #{ja_text}
+        EOS
+      end
+    end # class Plan
+  end # module Command
+end # module Swimmy

--- a/lib/swimmy/service.rb
+++ b/lib/swimmy/service.rb
@@ -20,5 +20,7 @@ module Swimmy
     autoload :RecipeInfomation, "#{dir}/recipe_information.rb"
     autoload :Bookmark, "#{dir}/bookmark.rb"
     autoload :Karaoke, "#{dir}/karaoke.rb"
+    autoload :Translate, "#{dir}/translate.rb"
+    autoload :Numbersapi, "#{dir}/numbersapi.rb"
   end
 end

--- a/lib/swimmy/service/numbersapi.rb
+++ b/lib/swimmy/service/numbersapi.rb
@@ -1,0 +1,32 @@
+module Swimmy
+  module Service
+    class Numbersapi
+      require 'json'
+      require 'uri'
+      require 'net/http'
+      
+      def initialize
+        @base_url = "http://numbersapi.com"
+      end
+
+      def fetch_date_event(month=0, day=0)
+        url = @base_url << "/#{month}/#{day}/date?json"
+        fetch(url)
+      end
+
+      def fetch_year_event(year=0)
+        url = @base_url << "/#{year}/year?json"
+        fetch(url)
+      end
+
+      private
+
+      def fetch(url)
+        parsed_uri = URI.parse(url)
+        json = Net::HTTP.get_response(parsed_uri).body
+        parsed_json = JSON.parse(json)
+        if parsed_json["found"]==true then parsed_json["text"] else nil end
+      end
+    end
+  end
+end

--- a/lib/swimmy/service/translate.rb
+++ b/lib/swimmy/service/translate.rb
@@ -1,0 +1,47 @@
+module Swimmy
+  module Service
+    class Translate
+      require 'json'
+      require 'uri'
+      require 'net/http'
+
+      #===language_select====
+      # Japanese : "ja"
+      # English  : "en"
+      #======================
+      
+      def initialize(source_lang, target_lang)
+        @source_lang = source_lang
+        @target_lang = target_lang
+      end
+
+      def translate(text)
+        translate_uri = "#{ENV['TRANSLATE_API_URL']}"
+        translate_uri << "?text=#{text}&source=#{@source_lang}&target=#{@target_lang}"
+        translate_json = fetch_with_redirect(translate_uri)
+        translate_content = JSON.parse(translate_json)
+
+        if translate_content["code"]==200 then translate_content["text"] else nil end
+      end
+
+      private
+
+      def fetch_with_redirect(uri_str, limit = 5)
+        raise 'Too many HTTP redirects' if limit == 0
+    
+        parsed_uri = URI.parse(uri_str)
+        response = Net::HTTP.get_response(parsed_uri)        
+        case response
+        when Net::HTTPSuccess
+          return response.body
+        when Net::HTTPRedirection
+          location = response['location']
+          warn "redirected to #{location}"
+          fetch_with_redirect(location, limit - 1)
+        else
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
hizuki コマンドの追加
# コマンドの概要
## 機能
引数に指定した年や月日に起きたとされる出来事を表示する．
## 使用方法
`swimmy hizuki <引数>` と入力すると引数に指定した年や月日に起きたとされる出来事を表示する．
<引数>が受け付ける内容は以下のとおりである．
・現在の西暦より小さい0以外の整数
・<月>/<日>の書式で入力された存在する月日
## 特徴
出来事の英語情報を取得するためにNumbers APIを利用し，英語を翻訳するためにGASで作成した翻訳プログラムを使用している．