### PR TITLE
Add error message when launching on unsupported OS

### DIFF
--- a/exe/google_oauth_initializer
+++ b/exe/google_oauth_initializer
@@ -82,17 +82,20 @@ end
 
 def open_browser(url)
   res = nil
-  if OS.windows?
-    res = system('start', url)
-  elsif OS.mac?
-    res = system('open', url)
-  elsif OS.linux?
-    res = system('xdg-open', url)
-  end
+  begin
+    if OS.windows?
+      res = system('start', url)
+    elsif OS.mac?
+      res = system('open', url)
+    elsif OS.linux?
+      res = system('xdg-open', url)
+    end
+  rescue
 
-  if (res.nil? || res == false)
-    puts 'Open below URL with your browser'
-    puts url
+    if (res.nil? || res == false)
+      puts 'Open below URL with your browser'
+      puts url
+    end
   end
 end
 


### PR DESCRIPTION
## 問題点

WSL 環境などの対応した OS ではあるが，ブラウザを開くための対応したコマンドがない環境において，system メソッドでエラーを起こしていた．そのため，ブラウザを直接開くよう指示する内容のエラーメッセージを表示できていなかった．

## 対処
例外処理を追加し，対応するコマンドがない場合にもエラーメッセージが表示されるようにした．