### PR TITLE
Bump up dependencies and ruby version for GitHub Actions

### DIFF
--- a/.github/workflows/swimmy.yml
+++ b/.github/workflows/swimmy.yml
@@ -31,7 +31,7 @@ jobs:
       uses: ruby/setup-ruby@v1
     # uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
-        ruby-version: 2.6.5
+        ruby-version: 2.7.8
     - name: Install dependencies
       run: bundle install
     - name: Run RSpec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/yoshinari-nomura/slack_socket_mode_bot.git
-  revision: bd04ad18c27948146b37c578eb902c8acd818c94
+  revision: 9d095d2ccfae87c99b1c949fbd67af1da2043aac
   branch: main
   specs:
     slack_socket_mode_bot (0.9.1)
@@ -58,13 +58,13 @@ GEM
       mail
       thor (>= 0.19.1)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.3)
     console (1.19.0)
       fiber-annotation
       fiber-local
     date (3.4.1)
     declarative (0.0.20)
-    diff-lcs (1.6.1)
+    diff-lcs (1.6.2)
     dotenv (2.8.1)
     drb (2.2.1)
     enumdate (0.1.1)
@@ -110,13 +110,13 @@ GEM
       net-smtp
     memoist (0.16.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     mqtt (0.6.0)
     multi_json (1.15.0)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
-    net-imap (0.4.19)
+    net-imap (0.4.22)
       date
       net-protocol
     net-pop (0.1.2)
@@ -145,13 +145,13 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
+    rspec-support (3.13.3)
     securerandom (0.3.2)
     signet (0.19.0)
       addressable (~> 2.8)


### PR DESCRIPTION
## 概要
1. slack_socket_mode_bot のバージョンが古く，引数が一致していない問題を解決するために，Gemfile.lock を更新した．
2. GitHub Actions で使用されている Ruby のバージョンが古く，gem の依存関係を解決できない問題を解消するために，GitHub Actions で使用される Ruby のバージョンを 2.7.8 に更新した．