### PR TITLE
Update attendance command to be able to execute with a user name.

### DIFF
--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -8,10 +8,24 @@ module Swimmy
       command 'hi', 'bye' do |client, data, match|
 
         cmd = match[:command]
+        arg = match[:expression]
         now = Time.now
         user = client.web_client.users_info(user: data.user).user
         user_id = user.id
-        user_name = user.profile.display_name
+
+        case parse_arg(arg)
+        when "do_current_user"
+          # if no argument
+          user_name = user.profile.display_name
+        when "do_specified_user"
+          # if the user specified in the argument is active
+          user_name = arg
+        when "not_active_user"
+          # if the user specified in the argument is not active
+          msg = "ユーザ #{arg}は現役メンバではありません．"
+          client.say(channel: data.channel, text: msg)
+          next
+        end
 
         # log to spreadsheet
         now_s = now.strftime("%Y-%m-%d %H:%M:%S")
@@ -36,8 +50,27 @@ module Swimmy
         title "attendance"
         desc "hi/bye で入退室をスプレッドシートに記録し，ドアプレートを更新します"
         long_desc "attendance (hi|bye)\n" +
-                  "もしくは，メンションで hi/bye だけでも OK です．"
+                  "もしくは，メンションで hi/bye だけでも OK です．\n" +
+                  "attendance (hi|bye) [MEMBER]\n" +
+                  "[MEMBER] を指定して，attendance コマンドを実行します"
       end
+
+      def self.parse_arg(arg)
+        # judge if the user is specified in the argument
+        active_members = spreadsheet.sheet("members", Swimmy::Resource::Member).fetch.select {|m| m.active? }.map {|m| m.account }
+
+        case arg
+        in nil
+          # return "do_current_user" if arg is not specified
+          return "do_current_user"
+        in String => s if active_members.include?(s)
+          # return "do_specified_user" if the user specified in the argument is active
+          return "do_specified_user"
+        else
+          # return "not_active_user" if the user specified in the argument is not active
+          return "not_active_user"
+        end
+      end # method parse_arg
     end # class Attendance
   end # module Command
 end # module Swimmy


### PR DESCRIPTION
# 概要
+ attendance コマンドを，引数でユーザ名を指定して実行できるようにアップデートした．
  + 引数が指定された場合，そのユーザ名で attendance コマンドを実行する．このとき，指定されたユーザ名が現役メンバのものでない場合は，attendance コマンドは失敗し，エラーメッセージを出力する．
  + 引数が指定されなかった場合，従来どおり，コマンドの発言者のユーザ名で attendance コマンドを実行する．
+ また，上記に伴い，help コマンドで表示するヘルプメッセージをアップデートした．

