### PR TITLE
fix hizuki.rb and translate.rb

### DIFF
--- a/lib/swimmy/command/hizuki.rb
+++ b/lib/swimmy/command/hizuki.rb
@@ -16,6 +16,9 @@ module Swimmy
           message = self.get_date_event_message($1.to_i, $2.to_i)
         when year_expr
           message = self.get_year_event_message($1.to_i)
+        when nil
+          today = Date.today
+          message = self.get_date_event_message(today.month, today.day)
         when "help"
           message = help_message("hizuki")
         else


### PR DESCRIPTION
+ lib/swimmy/service/translate.rbにおいて，使用する環境変数がない場合や環境変数が望ましいものでなかった場合に処理が止まりslack上に何も表示されないようになっていた．これについて，翻訳の失敗として処理してslack上には英字のメッセージと翻訳をできなかった旨を伝える日本語を表示するようにした．

+ `swimmy hizuki`の後ろに年や月日を表す引数がない場合，slackj上にhizuki helpの入力を要求するメッセージを表示していた．これについて引数がない場合は，本日の日付に関するメッセージを表示するようにした．