### PR TITLE
Fix attendance command to be able to handle cases where trailing spac…

### DIFF
--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -8,7 +8,7 @@ module Swimmy
       command 'hi', 'bye' do |client, data, match|
 
         cmd = match[:command]
-        arg = match[:expression]
+        arg = match[:expression]&.strip
         now = Time.now
         user = client.web_client.users_info(user: data.user).user
         user_id = user.id
@@ -60,7 +60,7 @@ module Swimmy
         active_members = spreadsheet.sheet("members", Swimmy::Resource::Member).fetch.select {|m| m.active? }.map {|m| m.account }
 
         case arg
-        in nil
+        in nil | ""
           # return "do_current_user" if arg is not specified
           return "do_current_user"
         in String => s if active_members.include?(s)


### PR DESCRIPTION
# 概要
+ attendance コマンドについて，hi/bye の後ろに空白が入っている場合，空白をユーザ名として解釈してしまうという問題が見つかった．
+ 上記に対処するため，hi/bye の後ろに続く文字列に，前後の空白トリミング処理を追加した．
