### PR TITLE
Enhance error message for photo upload failure to include filename

### DIFF
--- a/lib/swimmy/command/photo_upload.rb
+++ b/lib/swimmy/command/photo_upload.rb
@@ -39,7 +39,7 @@ module Swimmy
                          text: "アップロード完了 #{url}",
                          thread_ts: data.thread_ts || data.ts)
             rescue
-              message = '写真のアップロードに失敗しました．'
+              message = "写真のアップロードに失敗しました (ファイル名: #{file.name})．"
               client.say(channel: data.channel, text: message)
             end
           end


### PR DESCRIPTION
This PR makes it clear which photos failed to upload when an error occurs during photos upload.