### PR TITLE
Support door-mgr

### DIFF
--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -42,8 +42,12 @@ module Swimmy
         client.say(channel: data.channel, text: "履歴を記録しました．")
 
         # attendance event (for doorplate)
+        attendance_labels = {
+          "hi" => "在室",
+          "bye" => "帰宅"
+        }
         doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-        doorplate_service.send_attendance_event(cmd, user_id, user_name)
+        doorplate_service.send_attendance_event(attendance_labels[cmd], user_name)
       end
 
       help do

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -41,7 +41,7 @@ module Swimmy
         if match_locations.length == 1
           begin
             doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-            doorplate_service.send_attendance_event(match_locations.keys.first, user_id, user_name)
+            doorplate_service.send_attendance_event(match_locations.values.first, user_name)
           rescue => e
             client.say(channel: data.channel, text: "ドアプレートの状態を更新できませんでした．")
             return

--- a/lib/swimmy/service/doorplate.rb
+++ b/lib/swimmy/service/doorplate.rb
@@ -5,16 +5,13 @@ module Swimmy
         @mqtt = mqtt_client
       end
 
-      def send_attendance_event(attendance, user_id, user_name)
+      def send_attendance_event(attendance, user_name)
         require "json"
 
-        topic = "dt/swimmy/v1/ou/eng4/nomlab/swimmy/attend"
+        topic = "cmd/pinot/v1/ou/eng4/doormgr/state"
         payload = JSON.dump({
-          attendance: attendance,
-          slack_user: {
-            id: user_id,
-            name: user_name,
-          },
+          member: user_name.tr('-','_'),
+          position: attendance,
         })
 
         @mqtt.publish(topic, payload)


### PR DESCRIPTION
## 概要
door-mgr に対応するように MQTT のトピックの変更および pub するメッセージを変更した．

## 変更内容
- トピックを `dt/swimmy/v1/ou/eng4/nomlab/swimmy/attend` から `cmd/pinot/v1/ou/eng4/doormgr/state` に変更した
- pub する JSON のメンバを変更した