### PR TITLE
Support door-mgr

### DIFF
--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -42,8 +42,12 @@ module Swimmy
         client.say(channel: data.channel, text: "履歴を記録しました．")
 
         # attendance event (for doorplate)
+        attendance_labels = {
+          "hi" => "在室",
+          "bye" => "帰宅"
+        }
         doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-        doorplate_service.send_attendance_event(cmd, user_id, user_name)
+        doorplate_service.send_attendance_event(attendance_labels[cmd], user_name)
       end
 
       help do

--- a/lib/swimmy/command/attendance.rb
+++ b/lib/swimmy/command/attendance.rb
@@ -11,7 +11,6 @@ module Swimmy
         arg = match[:expression]&.strip
         now = Time.now
         user = client.web_client.users_info(user: data.user).user
-        user_id = user.id
 
         case parse_arg(arg)
         when "do_current_user"
@@ -44,10 +43,13 @@ module Swimmy
         # attendance event (for doorplate)
         attendance_labels = {
           "hi" => "在室",
-          "bye" => "帰宅"
+          "bye" => user_name == "nom" ? "帰宅・出張" : "帰宅"
         }
-        doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-        doorplate_service.send_attendance_event(attendance_labels[cmd], user_name)
+        position = attendance_labels[cmd]
+        if position
+          doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
+          doorplate_service.pub_doormgr_state(position, user_name)
+        end
       end
 
       help do

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -41,7 +41,7 @@ module Swimmy
         if match_locations.length == 1
           begin
             doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-            doorplate_service.send_attendance_event(match_locations.keys.first, user_id, user_name)
+            doorplate_service.send_attendance_event(match_locations.values.first, user_name)
           rescue => e
             client.say(channel: data.channel, text: "ドアプレートの状態を更新できませんでした．")
             return

--- a/lib/swimmy/command/location.rb
+++ b/lib/swimmy/command/location.rb
@@ -41,7 +41,7 @@ module Swimmy
         if match_locations.length == 1
           begin
             doorplate_service = Swimmy::Service::Doorplate.new(mqtt_client)
-            doorplate_service.send_attendance_event(match_locations.values.first, user_name)
+            doorplate_service.pub_doormgr_state(match_locations.values.first, user_name)
           rescue => e
             client.say(channel: data.channel, text: "ドアプレートの状態を更新できませんでした．")
             return

--- a/lib/swimmy/service/doorplate.rb
+++ b/lib/swimmy/service/doorplate.rb
@@ -5,16 +5,13 @@ module Swimmy
         @mqtt = mqtt_client
       end
 
-      def send_attendance_event(attendance, user_id, user_name)
+      def send_attendance_event(attendance, user_name)
         require "json"
 
-        topic = "dt/swimmy/v1/ou/eng4/nomlab/swimmy/attend"
+        topic = "cmd/pinot/v1/ou/eng4/doormgr/state"
         payload = JSON.dump({
-          attendance: attendance,
-          slack_user: {
-            id: user_id,
-            name: user_name,
-          },
+          member: user_name.tr('-','_'),
+          position: attendance,
         })
 
         @mqtt.publish(topic, payload)

--- a/lib/swimmy/service/doorplate.rb
+++ b/lib/swimmy/service/doorplate.rb
@@ -10,6 +10,9 @@ module Swimmy
 
         topic = "cmd/pinot/v1/ou/eng4/doormgr/state"
         payload = JSON.dump({
+          # Slack の user_name と door-mgr の member は対応している．
+          # しかし door-mgr では`-`が利用できず`_`に置換したものを期待しているため変換する．
+          # e.g. user_name: "fujiwara-e" -> member: "fujiwara_e"
           member: user_name.tr('-','_'),
           position: attendance,
         })

--- a/lib/swimmy/service/doorplate.rb
+++ b/lib/swimmy/service/doorplate.rb
@@ -5,7 +5,7 @@ module Swimmy
         @mqtt = mqtt_client
       end
 
-      def send_attendance_event(attendance, user_name)
+      def pub_doormgr_state(position, user_name)
         require "json"
 
         topic = "cmd/pinot/v1/ou/eng4/doormgr/state"
@@ -14,7 +14,7 @@ module Swimmy
           # しかし door-mgr では`-`が利用できず`_`に置換したものを期待しているため変換する．
           # e.g. user_name: "fujiwara-e" -> member: "fujiwara_e"
           member: user_name.tr('-','_'),
-          position: attendance,
+          position: position,
         })
 
         @mqtt.publish(topic, payload)


### PR DESCRIPTION
## 概要
door-mgr に対応するように MQTT のトピックの変更および pub するメッセージを変更した．

## 変更内容
- トピックを `dt/swimmy/v1/ou/eng4/nomlab/swimmy/attend` から `cmd/pinot/v1/ou/eng4/doormgr/state` に変更した
- pub する JSON のメンバを変更した