### PR TITLE
Fix help cmd

### DIFF
--- a/lib/swimmy/command/base.rb
+++ b/lib/swimmy/command/base.rb
@@ -87,7 +87,8 @@ module Swimmy
 
       def self.child_command_classes(command_classes)
         command_classes.reject do |k|
-          k.name&.starts_with?('SlackRubyBot::Commands::')
+          k.name&.starts_with?('SlackRubyBot::Commands::') &&
+          k != SlackRubyBot::Commands::Help
         end
       end
       private_class_method :child_command_classes


### PR DESCRIPTION
## 背景
 slack-ruby-bot gem への変更により，各コマンドの help メッセージが表示されなくなっていた．

## 原因
コマンド実行処理では，`SlackRubyBot::Commands::Base.command_classes` に登録されているクラスから slack-ruby-bot  が持つ標準コマンドを除き呼び出す．
この対象に `Help` も含まれていたため，`swimmy help <command>` が `Help` コマンドまで到達していなかった．

## 対応
引き続き標準コマンドは除外しつつ，`Help` だけ含めるようにした．

